### PR TITLE
set.seed in `data_partition()`

### DIFF
--- a/R/data_partition.R
+++ b/R/data_partition.R
@@ -56,6 +56,7 @@ data_partition <- function(x, training_proportion = 0.7, group = NULL) {
 
 #' @keywords internal
 .data_partition <- function(x, training_proportion = 0.8) {
+  set.seed(333)
   training_indices <- sample(1:nrow(x), size = training_proportion * nrow(x))
   test_indices <- (1:nrow(x))[-training_indices]
 

--- a/R/data_partition.R
+++ b/R/data_partition.R
@@ -16,7 +16,7 @@
 #' head(data_partition(df, group = "Species"))
 #' head(data_partition(df, group = c("Species", "Smell")))
 #' @export
-data_partition <- function(x, training_proportion = 0.7, group = NULL) {
+data_partition <- function(x, training_proportion = 0.7, group = NULL, seed = NULL) {
   if (!is.data.frame(x)) {
     x <- tryCatch(
       expr = {
@@ -31,7 +31,8 @@ data_partition <- function(x, training_proportion = 0.7, group = NULL) {
       stop("`x` needs to be a data frame, or an object that can be coerced to a data frame.")
     }
   }
-
+  if(is.null(seed) == FALSE){set.seed(seed)}
+  
   training <- data.frame()
   test <- data.frame()
 
@@ -56,7 +57,6 @@ data_partition <- function(x, training_proportion = 0.7, group = NULL) {
 
 #' @keywords internal
 .data_partition <- function(x, training_proportion = 0.8) {
-  set.seed(333)
   training_indices <- sample(1:nrow(x), size = training_proportion * nrow(x))
   test_indices <- (1:nrow(x))[-training_indices]
 

--- a/R/data_partition.R
+++ b/R/data_partition.R
@@ -32,7 +32,9 @@ data_partition <- function(x, training_proportion = 0.7, group = NULL, seed = NU
       stop("`x` needs to be a data frame, or an object that can be coerced to a data frame.")
     }
   }
-  if(is.null(seed) == FALSE){set.seed(seed)}
+  if (!is.null(seed)) { 
+    set.seed(seed)
+  }
   
   training <- data.frame()
   test <- data.frame()

--- a/R/data_partition.R
+++ b/R/data_partition.R
@@ -5,6 +5,7 @@
 #' @param x A data frame, or an object that can be coerced to a data frame.
 #' @param training_proportion The proportion (between 0 and 1) of the training set. The remaining part will be used for the test set.
 #' @param group A character vector indicating the name(s) of the column(s) used for stratified partitioning.
+#' @param seed A random number generator seed. Enter an integer (e.g., 123) so that the random sampling will be the same each time you run the function.
 #'
 #' @return A list of two data frames, named \code{test} and \code{training}.
 #'

--- a/man/data_partition.Rd
+++ b/man/data_partition.Rd
@@ -4,7 +4,7 @@
 \alias{data_partition}
 \title{Partition data into a test and a training set}
 \usage{
-data_partition(x, training_proportion = 0.7, group = NULL)
+data_partition(x, training_proportion = 0.7, group = NULL, seed = NULL)
 }
 \arguments{
 \item{x}{A data frame, or an object that can be coerced to a data frame.}
@@ -12,6 +12,8 @@ data_partition(x, training_proportion = 0.7, group = NULL)
 \item{training_proportion}{The proportion (between 0 and 1) of the training set. The remaining part will be used for the test set.}
 
 \item{group}{A character vector indicating the name(s) of the column(s) used for stratified partitioning.}
+
+\item{seed}{A random number generator seed. Enter an integer (e.g., 123) so that the random sampling will be the same each time you run the function.}
 }
 \value{
 A list of two data frames, named \code{test} and \code{training}.


### PR DESCRIPTION
It seems that the EFA factor loadings are different each time the data is split into training and test sets using `data_partition()`. We suspect this is because the sets are split differently with each run @DominiqueMakowski 

This should be easily resolved with `set.seed()` before running `sample()` 
