### PR TITLE
nnet::multinom (1 liner)

### DIFF
--- a/R/model_parameters.multinom.R
+++ b/R/model_parameters.multinom.R
@@ -73,7 +73,7 @@ model_parameters.bracl <- function(model,
   # detect number of levels of response
   nl <- tryCatch(
     {
-      nlevels(insight::get_response(model))
+      nlevels(factor(insight::get_response(model)))
     },
     error = function(e) {
       0


### PR DESCRIPTION
This is a 1-line commit

From the docs, I can't exactly tell if objects produced by `nnet::multinom` are supposed to be supported (looks like not), but I tried anyway. It works well, but the code assumes that the response variable is a factor. If the response is character, it doesn't work.

One solution is to convert the response to factor before counting the number of levels. There could also be a `length(unique())` strategy, but then you have to worry about `NAs`, so this seemed more straightforward.

MWE:

    library(parameters)
    library(nnet)

    # character response does not work
    var1 <- sample(c('A', 'B', 'C'), replace = T, size=100)
    var2 <- sample(c(0,1), size=100, replace=T)
    var3 <- rnorm(100, mean=10, sd=2)
    df1 <- data.frame(var1, var2, var3)

    mod1 <- nnet::multinom(var1~var2, data=df1)

    parameters(mod1)
    #> Warning in merge.data.frame(parameters, std_err, by = merge_by): column names
    #> 'Response.x', 'Response.y' are duplicated in the result
    #> Warning in merge.data.frame(parameters, statistic, by = merge_by): column names
    #> 'Response.x', 'Response.y' are duplicated in the result
    #> Parameter   | Log-Odds |   SE |        95% CI | Response |     t |     p | Response.1
    #> -------------------------------------------------------------------------------------
    #> (Intercept) |     0.14 | 0.31 | [-0.46, 0.74] |        B |  0.46 | 0.648 |          B
    #> var2        |    -0.14 | 0.47 | [-1.06, 0.78] |        B | -0.30 | 0.765 |          B
    #> (Intercept) |    -0.22 | 0.31 | [-0.46, 0.74] |        B |  0.46 | 0.648 |          B
    #> var2        |    -0.35 | 0.47 | [-1.06, 0.78] |        B | -0.30 | 0.765 |          B

    # factor response works
    var1 <- factor(var1)
    df2 <- data.frame(var1, var2, var3)

    mod2 <- nnet::multinom(var1~var2, data=df2)

    parameters(mod2)
    #> # Response level: b
    #> 
    #> Parameter   | Log-Odds |   SE |        95% CI | t(96) |     p
    #> -------------------------------------------------------------
    #> (Intercept) |     0.14 | 0.31 | [-0.46, 0.74] |  0.46 | 0.648
    #> var2        |    -0.14 | 0.47 | [-1.06, 0.78] | -0.30 | 0.765
    #> 
    #> # Response level: c
    #> 
    #> Parameter   | Log-Odds |   SE |        95% CI | t(96) |     p
    #> -------------------------------------------------------------
    #> (Intercept) |    -0.22 | 0.34 | [-0.88, 0.43] | -0.67 | 0.506
    #> var2        |    -0.35 | 0.53 | [-1.40, 0.70] | -0.66 | 0.510


