### PR TITLE
add Method column to BF models

### DIFF
--- a/R/methods_BayesFactor.R
+++ b/R/methods_BayesFactor.R
@@ -144,6 +144,10 @@ model_parameters.BFBayesFactor <- function(model,
     out$Parameter
   )
 
+  if (!"Method" %in% names(out)) {
+    out$Method <- .method_BFBayesFactor(model)
+  }
+
   attr(out, "ci") <- ci
   attr(out, "object_name") <- deparse(substitute(model), width.cutoff = 500)
   attr(out, "pretty_names") <- pretty_names
@@ -205,5 +209,27 @@ p_value.BFBayesFactor <- function(model, ...) {
     "proptest"
   } else {
     class(x@denominator)
+  }
+}
+
+.method_BFBayesFactor <- function(x) {
+  if (!requireNamespace("BayesFactor", quietly = TRUE)) {
+    stop("This function needs `BayesFactor` to be installed.")
+  }
+
+  if (any(class(x@denominator) %in% c("BFcorrelation"))) {
+    "Bayesian correlation analysis"
+  } else if (any(class(x@denominator) %in% c("BFoneSample", "BFindepSample"))) {
+    "Bayesian t-test"
+  } else if (any(class(x@denominator) %in% c("BFmetat"))) {
+    "Mata-analytic Bayes factors"
+  } else if (any(class(x@denominator) %in% c("BFlinearModel"))) {
+    "Bayes factors for linear models"
+  } else if (any(class(x@denominator) %in% c("BFcontingencyTable"))) {
+    "Bayesian contingency tabs analysis"
+  } else if (any(class(x@denominator) %in% c("BFproportion"))) {
+    "Bayesian proportion test"
+  } else {
+    NA_character_
   }
 }

--- a/R/methods_BayesFactor.R
+++ b/R/methods_BayesFactor.R
@@ -148,6 +148,7 @@ model_parameters.BFBayesFactor <- function(model,
     out$Method <- .method_BFBayesFactor(model)
   }
 
+  attr(out, "title") <- unique(out$Method)
   attr(out, "ci") <- ci
   attr(out, "object_name") <- deparse(substitute(model), width.cutoff = 500)
   attr(out, "pretty_names") <- pretty_names
@@ -222,7 +223,7 @@ p_value.BFBayesFactor <- function(model, ...) {
   } else if (any(class(x@denominator) %in% c("BFoneSample", "BFindepSample"))) {
     "Bayesian t-test"
   } else if (any(class(x@denominator) %in% c("BFmetat"))) {
-    "Mata-analytic Bayes factors"
+    "Meta-analytic Bayes factors"
   } else if (any(class(x@denominator) %in% c("BFlinearModel"))) {
     "Bayes factors for linear models"
   } else if (any(class(x@denominator) %in% c("BFcontingencyTable"))) {

--- a/tests/testthat/test-model_parameters.BFBayesFactor.R
+++ b/tests/testthat/test-model_parameters.BFBayesFactor.R
@@ -46,7 +46,7 @@ if (require("testthat") &&
 
     test_that("model_parameters.BFBayesFactor", {
       expect_equal(colnames(mp), c("Parameter", "Median", "CI_low", "CI_high", "pd", "ROPE_Percentage",
-                                   "Prior_Distribution", "Prior_Location", "Prior_Scale", "BF"))
+                                   "Prior_Distribution", "Prior_Location", "Prior_Scale", "BF", "Method"))
     })
 
     data(puzzles)
@@ -57,10 +57,10 @@ if (require("testthat") &&
     test_that("model_parameters.BFBayesFactor", {
       expect_equal(colnames(mp), c("Parameter", "Median", "CI_low", "CI_high", "pd", "ROPE_Percentage",
                                    "Prior_Distribution", "Prior_Location", "Prior_Scale", "Effects",
-                                   "Component", "BF"))
+                                   "Component", "BF", "Method"))
       expect_equal(mp$Effects, c("fixed", "fixed", "fixed", "fixed", "fixed", "random", "random",
                                  "random", "random", "random", "random", "random", "random", "random",
-                                 "random", "random", "random", "fixed", "fixed", "fixed", "fixed"))
+                                 "random", "random", "random", "fixed", "fixed", "fixed", "fixed", "Method"))
     })
   }
 }


### PR DESCRIPTION
Similar to `htest` output, I was thinking adding a `Method` column to `BayesFactor` output. What do you think?

``` r
library(BayesFactor)
#> Loading required package: coda
#> Loading required package: Matrix
#> ************
#> Welcome to BayesFactor 0.9.12-4.3. If you have questions, please contact Richard Morey (richarddmorey@gmail.com).
#> 
#> Type BFManual() to open the manual.
#> ************
library(parameters)

# example-1
mod <- ttestBF(x = sleep$extra[sleep$group==1], y = sleep$extra[sleep$group==2], paired=TRUE)

model_parameters(mod)
#> Parameter  | Median |         89% CI |     pd | % in ROPE |              Prior |    BF |          Method
#> --------------------------------------------------------------------------------------------------------
#> Difference |   1.42 | [ 0.69,  2.10] | 99.75% |        0% | Cauchy (0 +- 0.71) | 17.26 | Bayesian t-test
#> Cohen's D  |  -1.09 | [-1.83, -0.45] | 99.70% |        0% |                    |       | Bayesian t-test

# example-2
data(puzzles)
result <- anovaBF(RT ~ shape*color + ID, data = puzzles, whichRandom = "ID",
                  whichModels = 'top', progress = FALSE)
model_parameters(result, verbose = FALSE)
#> Multiple `BFBayesFactor` models detected - posteriors are extracted from the first numerator model.
#> See help("get_parameters", package = "insight").
#> # Extra Parameters
#> 
#> Parameter | Median |         89% CI |   pd | % in ROPE |    BF |                          Method
#> ------------------------------------------------------------------------------------------------
#> mu        |  45.00 | [43.94, 46.11] | 100% |        0% |  2.48 | Bayes factors for linear models
#> sig2      |   1.77 | [ 1.13,  2.50] | 100% |        0% | 0.230 | Bayes factors for linear models
#> g_shape   |   0.34 | [ 0.02,  2.01] | 100% |    45.91% |  2.48 | Bayes factors for linear models
#> g_color   |   0.36 | [ 0.02,  2.29] | 100% |    43.08% | 0.221 | Bayes factors for linear models
#> g_ID      |   2.62 | [ 0.75,  5.13] | 100% |        0% | 0.230 | Bayes factors for linear models
#> 
#> # Fixed Effects
#> 
#> Parameter             | Median |         89% CI |     pd | % in ROPE |              Prior |    BF |                          Method
#> -----------------------------------------------------------------------------------------------------------------------------------
#> shape [round]         |   0.43 | [ 0.14,  0.74] | 98.47% |    13.09% | Cauchy (0 +- 0.50) | 0.221 | Bayes factors for linear models
#> shape [square]        |  -0.43 | [-0.74, -0.14] | 98.47% |    13.09% | Cauchy (0 +- 0.50) | 0.230 | Bayes factors for linear models
#> color                 |  -0.42 | [-0.72, -0.11] | 98.72% |    15.98% | Cauchy (0 +- 0.50) |  2.48 | Bayes factors for linear models
#> color [monochromatic] |   0.42 | [ 0.11,  0.72] | 98.72% |    15.98% | Cauchy (0 +- 0.50) | 0.221 | Bayes factors for linear models
#> 
#> # Random Effects
#> 
#> Parameter | Median |         89% CI |     pd | % in ROPE |           Prior |    BF |                          Method
#> --------------------------------------------------------------------------------------------------------------------
#> ID [1]    |   2.47 | [ 0.96,  3.83] | 99.67% |        0% | Cauchy (0 +- 1) | 0.230 | Bayes factors for linear models
#> ID [2]    |   0.46 | [-1.03,  1.88] | 69.08% |    22.94% | Cauchy (0 +- 1) |  2.48 | Bayes factors for linear models
#> ID [3]    |   0.90 | [-0.46,  2.36] | 84.50% |    14.94% | Cauchy (0 +- 1) | 0.221 | Bayes factors for linear models
#> ID [4]    |   0.45 | [-0.90,  1.91] | 70.20% |    22.35% | Cauchy (0 +- 1) | 0.230 | Bayes factors for linear models
#> ID [5]    |   3.15 | [ 1.72,  4.63] | 99.98% |        0% | Cauchy (0 +- 1) |  2.48 | Bayes factors for linear models
#> ID [6]    |   0.45 | [-1.00,  1.76] | 70.45% |    23.08% | Cauchy (0 +- 1) | 0.221 | Bayes factors for linear models
#> ID [7]    |  -3.16 | [-4.58, -1.72] | 99.95% |        0% | Cauchy (0 +- 1) | 0.230 | Bayes factors for linear models
#> ID [8]    |  -0.23 | [-1.79,  1.13] | 61.15% |    24.88% | Cauchy (0 +- 1) |  2.48 | Bayes factors for linear models
#> ID [9]    |  -2.46 | [-3.81, -0.96] | 99.58% |        0% | Cauchy (0 +- 1) | 0.221 | Bayes factors for linear models
#> ID [10]   |   0.67 | [-0.72,  2.13] | 77.78% |    19.35% | Cauchy (0 +- 1) | 0.230 | Bayes factors for linear models
#> ID [11]   |   0.69 | [-0.78,  2.05] | 78.35% |    19.46% | Cauchy (0 +- 1) |  2.48 | Bayes factors for linear models
#> ID [12]   |  -3.37 | [-4.89, -2.03] |   100% |        0% | Cauchy (0 +- 1) | 0.221 | Bayes factors for linear models
```

<sup>Created on 2021-01-09 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>
