### PR TITLE
add support of emmeans to bootstrapped models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -79,6 +79,7 @@ Suggests:
     dplyr,
     DRR,
     effectsize (>= 0.4.3),
+    emmeans (>= 1.4),
     EGAnet (>= 0.7),
     FactoMineR,
     fastICA,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # parameters 0.11.1
 
+## General
+
+* Roll-back R dependency to R >= 3.4.
+
+* Bootstrapped estimates (from `bootstrap_model()` or `bootstrap_parameters()`) can be passed to `emmeans` to obtain bootstrapped estimates, contrasts, simple slopes (etc) and their CIs.
+  * These can then be passed to `model_parameters()` and related functions to obtain standard errors, p-values, etc.
+
 ## Breaking changes
 
 * `model_parameters()` now always returns the confidence level for as additional
@@ -10,12 +17,6 @@
 ## New supported model classes
 
 * `crr` (*cmprsk*)
-
-## General
-
-* Roll-back R dependency to R >= 3.4.
-
-* Bootstrapped estimates (from `bootstrap_model()` or `bootstrap_parameters()`) can be passed to `emmeans` to obtain bootstrapped estimates, contrasts, simple slopes (etc) and their CIs.
 
 ## Changes to functions
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,8 @@
 
 * Roll-back R dependency to R >= 3.4.
 
+* Bootstrapped estimates (from `bootstrap_model()` or `bootstrap_parameters()`) can be passed to `emmeans` to obtain bootstrapped estimates, contrasts, simple slopes (etc) and their CIs.
+
 ## Changes to functions
 
 * `model_parameters()` for mixed models gains an `effects`-argument, to

--- a/R/bootstrap_model-emmeans.R
+++ b/R/bootstrap_model-emmeans.R
@@ -10,6 +10,7 @@ emm_basis.bootstrap_model <- function(object, trms, xlev, grid, ...) {
     stop("Oops! Cannot create the reference grid. Please open an issue at github.com/easystats/parameters/issues.")
 
   emb$post.beta <- as.matrix(object)
+  emb$misc$is_boot <- TRUE
   emb
 }
 

--- a/R/bootstrap_model-emmeans.R
+++ b/R/bootstrap_model-emmeans.R
@@ -1,7 +1,7 @@
 #' @keywords emmeans_methods
 emm_basis.bootstrap_model <- function(object, trms, xlev, grid, ...) {
   if (!requireNamespace("emmeans", quietly = TRUE))
-    stop("Thin function requires the 'emmeans' package to work.")
+    stop("this function requires the 'emmeans' package to work.")
 
   model <- attr(object, "original_model")
   emb <- emmeans::emm_basis(model, trms, xlev, grid, ...)
@@ -16,7 +16,7 @@ emm_basis.bootstrap_model <- function(object, trms, xlev, grid, ...) {
 #' @keywords emmeans_methods
 recover_data.bootstrap_model <- function(object, ...) {
   if (!requireNamespace("emmeans", quietly = TRUE))
-    stop("Thin function requires the 'emmeans' package to work.")
+    stop("this function requires the 'emmeans' package to work.")
 
   model <- attr(object, "original_model")
   emmeans::recover_data(model, ...)
@@ -26,7 +26,7 @@ recover_data.bootstrap_model <- function(object, ...) {
 #' @keywords emmeans_methods
 emm_basis.bootstrap_parameters <- function(object, trms, xlev, grid, ...) {
   if (!requireNamespace("emmeans", quietly = TRUE))
-    stop("Thin function requires the 'emmeans' package to work.")
+    stop("this function requires the 'emmeans' package to work.")
 
   model <- attr(object, "boot_samples")
   emmeans::emm_basis(model, trms, xlev, grid, ...)
@@ -35,7 +35,7 @@ emm_basis.bootstrap_parameters <- function(object, trms, xlev, grid, ...) {
 #' @keywords emmeans_methods
 recover_data.bootstrap_parameters <- function(object, ...) {
   if (!requireNamespace("emmeans", quietly = TRUE))
-    stop("Thin function requires the 'emmeans' package to work.")
+    stop("this function requires the 'emmeans' package to work.")
 
   model <- attr(object, "boot_samples")
   emmeans::recover_data(model, ...)

--- a/R/bootstrap_model-emmeans.R
+++ b/R/bootstrap_model-emmeans.R
@@ -1,0 +1,42 @@
+#' @keywords emmeans_methods
+emm_basis.bootstrap_model <- function(object, trms, xlev, grid, ...) {
+  if (!requireNamespace("emmeans", quietly = TRUE))
+    stop("Thin function requires the 'emmeans' package to work.")
+
+  model <- attr(object, "original_model")
+  emb <- emmeans::emm_basis(model, trms, xlev, grid, ...)
+
+  if (ncol(object) != ncol(emb$V) || !all(colnames(object) == colnames(emb$V)))
+    stop("Oops! Cannot create the reference grid. Please open an issue at github.com/easystats/parameters/issues.")
+
+  emb$post.beta <- as.matrix(object)
+  emb
+}
+
+#' @keywords emmeans_methods
+recover_data.bootstrap_model <- function(object, ...) {
+  if (!requireNamespace("emmeans", quietly = TRUE))
+    stop("Thin function requires the 'emmeans' package to work.")
+
+  model <- attr(object, "original_model")
+  emmeans::recover_data(model, ...)
+}
+
+
+#' @keywords emmeans_methods
+emm_basis.bootstrap_parameters <- function(object, trms, xlev, grid, ...) {
+  if (!requireNamespace("emmeans", quietly = TRUE))
+    stop("Thin function requires the 'emmeans' package to work.")
+
+  model <- attr(object, "boot_samples")
+  emmeans::emm_basis(model, trms, xlev, grid, ...)
+}
+
+#' @keywords emmeans_methods
+recover_data.bootstrap_parameters <- function(object, ...) {
+  if (!requireNamespace("emmeans", quietly = TRUE))
+    stop("Thin function requires the 'emmeans' package to work.")
+
+  model <- attr(object, "boot_samples")
+  emmeans::recover_data(model, ...)
+}

--- a/R/bootstrap_model.R
+++ b/R/bootstrap_model.R
@@ -7,15 +7,25 @@
 #' @param ... Arguments passed to or from other methods.
 #' @inheritParams p_value
 #'
-#' @return A data frame.
+#' @return A data frame of bootstrapped estimates.
+#'
+#' @section Using with \code{emmeans}:
+#' The output can be passed directly to the various functions from the
+#' \code{emmeans} package, to obtain bootstrapped estimates, contrasts, siple
+#' slopes, etc, and their confidence intervals.
 #'
 #' @seealso \code{\link{bootstrap_parameters}}, \code{\link{simulate_model}}, \code{\link{simulate_parameters}}
 #'
 #' @examples
 #' \donttest{
 #' if (require("boot")) {
-#'   model <- lm(mpg ~ wt + cyl, data = mtcars)
-#'   head(bootstrap_model(model))
+#'   model <- lm(mpg ~ wt + factor(cyl), data = mtcars)
+#'   b <- bootstrap_model(model)
+#'   print(head(b))
+#'
+#'   if (require("emmeans")) {
+#'     print(emmeans(b, consec ~ cyl))
+#'   }
 #' }
 #' }
 #' @export
@@ -62,6 +72,7 @@ bootstrap_model.default <- function(model, iterations = 1000, verbose = FALSE, .
   names(out) <- insight::get_parameters(model)$Parameter
 
   class(out) <- unique(c("bootstrap_model", "see_bootstrap_model", class(out)))
+  attr(out, "original_model") <- model
   out
 }
 
@@ -89,6 +100,7 @@ bootstrap_model.merMod <- function(model, iterations = 1000, verbose = FALSE, ..
   names(out) <- insight::find_parameters(model, effects = "fixed")$conditional
 
   class(out) <- unique(c("bootstrap_model", "see_bootstrap_model", class(out)))
+  attr(out, "original_model") <- model
   out
 }
 

--- a/R/bootstrap_model.R
+++ b/R/bootstrap_model.R
@@ -12,7 +12,9 @@
 #' @section Using with \code{emmeans}:
 #' The output can be passed directly to the various functions from the
 #' \code{emmeans} package, to obtain bootstrapped estimates, contrasts, simple
-#' slopes, etc, and their confidence intervals.
+#' slopes, etc, and their confidence intervals. These can then be passed to
+#' \code{model_parameter()} to obtain standard errors, p-values, etc (see
+#' example).
 #'
 #' @seealso \code{\link{bootstrap_parameters}}, \code{\link{simulate_model}}, \code{\link{simulate_parameters}}
 #'
@@ -24,7 +26,8 @@
 #'   print(head(b))
 #'
 #'   if (require("emmeans")) {
-#'     print(emmeans(b, consec ~ cyl))
+#'     est <- emmeans(b, consec ~ cyl)
+#'     print(model_parameters(est))
 #'   }
 #' }
 #' }

--- a/R/bootstrap_model.R
+++ b/R/bootstrap_model.R
@@ -11,7 +11,7 @@
 #'
 #' @section Using with \code{emmeans}:
 #' The output can be passed directly to the various functions from the
-#' \code{emmeans} package, to obtain bootstrapped estimates, contrasts, siple
+#' \code{emmeans} package, to obtain bootstrapped estimates, contrasts, simple
 #' slopes, etc, and their confidence intervals.
 #'
 #' @seealso \code{\link{bootstrap_parameters}}, \code{\link{simulate_model}}, \code{\link{simulate_parameters}}

--- a/R/bootstrap_parameters.R
+++ b/R/bootstrap_parameters.R
@@ -28,7 +28,8 @@
 #'   print(b)
 #'
 #'   if (require("emmeans")) {
-#'     print(emmeans(b, trt.vs.ctrl ~ Species))
+#'     est <- emmeans(b, trt.vs.ctrl ~ Species)
+#'     print(model_parameters(est))
 #'   }
 #' }
 #' }

--- a/R/bootstrap_parameters.R
+++ b/R/bootstrap_parameters.R
@@ -7,7 +7,9 @@
 #' @inheritParams bootstrap_model
 #' @inheritParams bayestestR::describe_posterior
 #'
-#' @return Bootstrapped parameters.
+#' @return A data frame summarizing the bootstrapped parameters.
+#'
+#' @inheritSection bootstrap_model Using with \code{emmeans}
 #'
 #' @references Davison, A. C., & Hinkley, D. V. (1997). Bootstrap methods and their application (Vol. 1). Cambridge university press.
 #'
@@ -22,7 +24,12 @@
 #' \donttest{
 #' if (require("boot")) {
 #'   model <- lm(Sepal.Length ~ Species * Petal.Width, data = iris)
-#'   bootstrap_parameters(model)
+#'   b <- bootstrap_parameters(model)
+#'   print(b)
+#'
+#'   if (require("emmeans")) {
+#'     print(emmeans(b, trt.vs.ctrl ~ Species))
+#'   }
 #' }
 #' }
 #' @export
@@ -34,7 +41,7 @@ bootstrap_parameters <- function(model,
                                  test = "p-value",
                                  ...) {
   data <- bootstrap_model(model, iterations = iterations, ...)
-  .summary_bootstrap(
+  out <- .summary_bootstrap(
     data = data,
     test = test,
     centrality = centrality,
@@ -42,6 +49,10 @@ bootstrap_parameters <- function(model,
     ci_method = ci_method,
     ...
   )
+
+  class(out) <- c("bootstrap_parameters", "parameters_model", class(out))
+  attr(out, "boot_samples") <- data
+  out
 }
 
 
@@ -90,5 +101,6 @@ bootstrap_parameters <- function(model,
   }
 
   rownames(parameters) <- NULL
+  attr(parameters, "ci") <- ci
   parameters
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,4 @@
+.onLoad <- function(libname, pkgname) {
+  if (requireNamespace("emmeans", quietly = TRUE))
+    emmeans::.emm_register(c("bootstrap_model", "bootstrap_parameters"), pkgname)
+}

--- a/man/bootstrap_model.Rd
+++ b/man/bootstrap_model.Rd
@@ -25,7 +25,9 @@ Bootstrap a statistical model n times to return a data frame of estimates.
 
 The output can be passed directly to the various functions from the
 \code{emmeans} package, to obtain bootstrapped estimates, contrasts, simple
-slopes, etc, and their confidence intervals.
+slopes, etc, and their confidence intervals. These can then be passed to
+\code{model_parameter()} to obtain standard errors, p-values, etc (see
+example).
 }
 
 \examples{
@@ -36,7 +38,8 @@ if (require("boot")) {
   print(head(b))
 
   if (require("emmeans")) {
-    print(emmeans(b, consec ~ cyl))
+    est <- emmeans(b, consec ~ cyl)
+    print(model_parameters(est))
   }
 }
 }

--- a/man/bootstrap_model.Rd
+++ b/man/bootstrap_model.Rd
@@ -16,16 +16,28 @@ bootstrap_model(model, iterations = 1000, verbose = FALSE, ...)
 \item{...}{Arguments passed to or from other methods.}
 }
 \value{
-A data frame.
+A data frame of bootstrapped estimates.
 }
 \description{
 Bootstrap a statistical model n times to return a data frame of estimates.
 }
+\section{Using with \code{emmeans}}{
+
+The output can be passed directly to the various functions from the
+\code{emmeans} package, to obtain bootstrapped estimates, contrasts, siple
+slopes, etc, and their confidence intervals.
+}
+
 \examples{
 \donttest{
 if (require("boot")) {
-  model <- lm(mpg ~ wt + cyl, data = mtcars)
-  head(bootstrap_model(model))
+  model <- lm(mpg ~ wt + factor(cyl), data = mtcars)
+  b <- bootstrap_model(model)
+  print(head(b))
+
+  if (require("emmeans")) {
+    print(emmeans(b, consec ~ cyl))
+  }
 }
 }
 }

--- a/man/bootstrap_model.Rd
+++ b/man/bootstrap_model.Rd
@@ -24,7 +24,7 @@ Bootstrap a statistical model n times to return a data frame of estimates.
 \section{Using with \code{emmeans}}{
 
 The output can be passed directly to the various functions from the
-\code{emmeans} package, to obtain bootstrapped estimates, contrasts, siple
+\code{emmeans} package, to obtain bootstrapped estimates, contrasts, simple
 slopes, etc, and their confidence intervals.
 }
 

--- a/man/bootstrap_parameters.Rd
+++ b/man/bootstrap_parameters.Rd
@@ -49,7 +49,9 @@ This function first calls \code{\link{bootstrap_model}} to generate
 
 The output can be passed directly to the various functions from the
 \code{emmeans} package, to obtain bootstrapped estimates, contrasts, simple
-slopes, etc, and their confidence intervals.
+slopes, etc, and their confidence intervals. These can then be passed to
+\code{model_parameter()} to obtain standard errors, p-values, etc (see
+example).
 }
 
 \examples{
@@ -60,7 +62,8 @@ if (require("boot")) {
   print(b)
 
   if (require("emmeans")) {
-    print(emmeans(b, trt.vs.ctrl ~ Species))
+    est <- emmeans(b, trt.vs.ctrl ~ Species)
+    print(model_parameters(est))
   }
 }
 }

--- a/man/bootstrap_parameters.Rd
+++ b/man/bootstrap_parameters.Rd
@@ -34,7 +34,7 @@ to be estimated. Default to \code{.89} (89\%) for Bayesian models and \code{.95}
 \item{...}{Arguments passed to or from other methods.}
 }
 \value{
-Bootstrapped parameters.
+A data frame summarizing the bootstrapped parameters.
 }
 \description{
 Compute bootstrapped parameters and their related indices such as Confidence Intervals (CI) and p-values.
@@ -45,11 +45,23 @@ This function first calls \code{\link{bootstrap_model}} to generate
   are treated as "distribution", and is passed to \code{\link[bayestestR:describe_posterior]{describe_posterior()}}
   to calculate the related indices defined in the \code{"test"} argument.
 }
+\section{Using with \code{emmeans}}{
+
+The output can be passed directly to the various functions from the
+\code{emmeans} package, to obtain bootstrapped estimates, contrasts, siple
+slopes, etc, and their confidence intervals.
+}
+
 \examples{
 \donttest{
 if (require("boot")) {
   model <- lm(Sepal.Length ~ Species * Petal.Width, data = iris)
-  bootstrap_parameters(model)
+  b <- bootstrap_parameters(model)
+  print(b)
+
+  if (require("emmeans")) {
+    print(emmeans(b, trt.vs.ctrl ~ Species))
+  }
 }
 }
 }

--- a/man/bootstrap_parameters.Rd
+++ b/man/bootstrap_parameters.Rd
@@ -48,7 +48,7 @@ This function first calls \code{\link{bootstrap_model}} to generate
 \section{Using with \code{emmeans}}{
 
 The output can be passed directly to the various functions from the
-\code{emmeans} package, to obtain bootstrapped estimates, contrasts, siple
+\code{emmeans} package, to obtain bootstrapped estimates, contrasts, simple
 slopes, etc, and their confidence intervals.
 }
 

--- a/tests/testthat/test-bootstrap_emmeans.R
+++ b/tests/testthat/test-bootstrap_emmeans.R
@@ -16,6 +16,11 @@ if (require("testthat") && require("parameters")) {
     expect_equal(summary(emmeans::emmeans(b, ~ cyl))$emmean,
                  summary(emmeans::emmeans(model, ~ cyl))$emmean,
                  tolerance = 0.1)
+
+    mp <- model_parameters(emmeans::emmeans(b, consec ~ cyl))
+    expect_true("p" %in% colnames(mp))
+    expect_true("SE" %in% colnames(mp))
+    expect_equal(nrow(mp), 5)
   })
 
 
@@ -37,5 +42,10 @@ if (require("testthat") && require("parameters")) {
     expect_equal(summary(emmeans::emmeans(b, ~ cyl))$emmean,
                  summary(emmeans::emmeans(model, ~ cyl))$emmean,
                  tolerance = 0.1)
+
+    mp <- model_parameters(emmeans::emmeans(b, consec ~ cyl))
+    expect_true("p" %in% colnames(mp))
+    expect_true("SE" %in% colnames(mp))
+    expect_equal(nrow(mp), 5)
   })
 }

--- a/tests/testthat/test-bootstrap_emmeans.R
+++ b/tests/testthat/test-bootstrap_emmeans.R
@@ -1,0 +1,41 @@
+if (require("testthat") && require("parameters")) {
+  test_that("emmeans | lm", {
+    skip_if_not_installed("emmeans")
+    skip_if_not_installed("boot")
+
+    model <- lm(mpg ~ log(wt) + factor(cyl), data = mtcars)
+
+    set.seed(7)
+    b <- bootstrap_model(model, iterations = 1000)
+    expect_equal(summary(emmeans::emmeans(b, ~ cyl))$emmean,
+                 summary(emmeans::emmeans(model, ~ cyl))$emmean,
+                 tolerance = 0.1)
+
+    set.seed(7)
+    b <- bootstrap_parameters(model, iterations = 1000)
+    expect_equal(summary(emmeans::emmeans(b, ~ cyl))$emmean,
+                 summary(emmeans::emmeans(model, ~ cyl))$emmean,
+                 tolerance = 0.1)
+  })
+
+
+  test_that("emmeans | lmer", {
+    skip_if_not_installed("emmeans")
+    skip_if_not_installed("boot")
+    skip_if_not_installed("lme4")
+
+    model <- lme4::lmer(mpg ~ log(wt) + factor(cyl) + (1|gear), data = mtcars)
+
+    set.seed(7)
+    b <- bootstrap_model(model, iterations = 1000)
+    expect_equal(summary(emmeans::emmeans(b, ~ cyl))$emmean,
+                 summary(emmeans::emmeans(model, ~ cyl))$emmean,
+                 tolerance = 0.1)
+
+    set.seed(7)
+    b <- bootstrap_parameters(model, iterations = 1000)
+    expect_equal(summary(emmeans::emmeans(b, ~ cyl))$emmean,
+                 summary(emmeans::emmeans(model, ~ cyl))$emmean,
+                 tolerance = 0.1)
+  })
+}


### PR DESCRIPTION
This PR adds emmeans-methods for the bootstrap functions (see examples).

Some notes:
1. To do this I have to save the model and the bootstrapped estimates in the output object from both `bootstrap_model()` and `bootstrap_parameters()`. @strengejacke is that okay? 
2. This can probably be extended to the `simulate_model()` and `simulate_parameters()` as well.
3. (Wasn't sure where to address this in the `NEWS` file)

``` r
library(parameters)
library(emmeans)

model <- lm(mpg ~ log(wt) + factor(cyl), data = mtcars)

b <- bootstrap_model(model, iterations = 50)
head(b)
#>   (Intercept)    log(wt) factor(cyl)6 factor(cyl)8
#> 1    35.46647 -10.835075    -3.336407    -5.259839
#> 2    37.01599 -12.766090    -2.532144    -4.536621
#> 3    34.41191  -9.417361    -3.953449    -6.906399
#> 4    36.23839  -9.453581    -5.618538    -8.500304
#> 5    35.95811 -11.459697    -3.400162    -5.137954
#> 6    33.72223 -10.223921    -2.666147    -4.839145

emmeans(b, consec ~ cyl)
#> $emmeans
#>  cyl emmean lower.HPD upper.HPD
#>    4   22.5      19.8      26.5
#>    6   19.3      18.7      20.1
#>    8   17.4      16.2      18.9
#> 
#> Point estimate displayed: median 
#> HPD interval probability: 0.95 
#> 
#> $contrasts
#>  contrast estimate lower.HPD upper.HPD
#>  6 - 4       -3.14     -7.00    -0.675
#>  8 - 6       -2.01     -3.17     0.330
#> 
#> Point estimate displayed: median 
#> HPD interval probability: 0.95
```

or

``` r
(b <- bootstrap_parameters(model, iterations = 50))
#> Parameter    | Coefficient |          95% CI |      p
#> -----------------------------------------------------
#> (Intercept)  |       35.98 | [ 33.07, 39.12] | < .001
#> log(wt)      |      -11.39 | [-14.49, -8.43] | < .001
#> factor(cyl)6 |       -3.45 | [ -5.14, -0.75] | < .001
#> factor(cyl)8 |       -5.00 | [ -7.19, -2.30] | < .001

emmeans(b, consec ~ cyl)
#> $emmeans
#>  cyl emmean lower.HPD upper.HPD
#>    4   22.7      19.6      24.4
#>    6   19.3      18.3      20.1
#>    8   17.5      15.8      18.3
#> 
#> Point estimate displayed: median 
#> HPD interval probability: 0.95 
#> 
#> $contrasts
#>  contrast estimate lower.HPD upper.HPD
#>  6 - 4       -3.45     -5.22    -0.313
#>  8 - 6       -1.85     -3.23    -0.209
#> 
#> Point estimate displayed: median 
#> HPD interval probability: 0.95
```

<sup>Created on 2021-01-31 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
