### PR TITLE
Add the option to calculate Q1 and Q3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,12 @@ Authors@R:
            family = "Arel-Bundock",
            role = c("ctb"),
            email = "vincent.arel-bundock@umontreal.ca",
-           comment = c(ORCID = "0000-0003-1995-6531", Twitter = "@vincentab"))
+           comment = c(ORCID = "0000-0003-1995-6531", Twitter = "@vincentab")),
+    person(given = "Jeffrey",
+           family = "Girard",
+           role = c("ctb"),
+           email = "me@jmgirard.com",
+           comment = c(ORCID = "0000-0002-7359-3746", Twitter = "@jeffreymgirard"))
   )
 Description: Utilities for processing the parameters of various
     statistical models. Beyond computing p values, CIs, and other indices

--- a/R/describe_distribution.R
+++ b/R/describe_distribution.R
@@ -111,8 +111,8 @@ describe_distribution.numeric <- function(x,
     out <- cbind(
       out,
       data.frame(
-        Q1 = quantile(x, probs = 0.25, na.rm = TRUE),
-        Q3 = quantile(x, probs = 0.75, na.rm = TRUE)
+        Q1 = stats::quantile(x, probs = 0.25, na.rm = TRUE),
+        Q3 = stats::quantile(x, probs = 0.75, na.rm = TRUE)
       )
     )
   }

--- a/R/describe_distribution.R
+++ b/R/describe_distribution.R
@@ -180,7 +180,10 @@ describe_distribution.factor <- function(x, dispersion = TRUE, range = TRUE, ...
   if (is.null(dot.arguments[["iqr"]])) {
     out$IQR <- NULL
   }
-
+  if (is.null(dot.arguments[["quartiles"]])) {
+    out$Q1 <- NULL
+    out$Q3 <- NULL
+  }
 
   if (!range) {
     out$Min <- NULL
@@ -232,8 +235,12 @@ describe_distribution.character <- function(x, dispersion = TRUE, range = TRUE, 
   if (is.null(dot.arguments[["iqr"]])) {
     out$IQR <- NULL
   }
+  if (is.null(dot.arguments[["quartiles"]])) {
+    out$Q1 <- NULL
+    out$Q3 <- NULL
+  }
 
-  
+
   if (!range) {
     out$Min <- NULL
     out$Max <- NULL

--- a/R/describe_distribution.R
+++ b/R/describe_distribution.R
@@ -186,11 +186,6 @@ describe_distribution.factor <- function(x, dispersion = TRUE, range = TRUE, ...
     out$Min <- NULL
     out$Max <- NULL
   }
-  
-  if (!quartiles) {
-    out$Q1 <- NULL
-    out$Q3 <- NULL
-  }
 
   class(out) <- unique(c("parameters_distribution", "see_parameters_distribution", class(out)))
   attr(out, "data") <- x
@@ -238,15 +233,10 @@ describe_distribution.character <- function(x, dispersion = TRUE, range = TRUE, 
     out$IQR <- NULL
   }
 
-
+  
   if (!range) {
     out$Min <- NULL
     out$Max <- NULL
-  }
-  
-  if (!quartiles) {
-    out$Q1 <- NULL
-    out$Q3 <- NULL
   }
 
   class(out) <- unique(c("parameters_distribution", "see_parameters_distribution", class(out)))

--- a/R/describe_distribution.R
+++ b/R/describe_distribution.R
@@ -5,6 +5,7 @@
 #'
 #' @param x A numeric vector.
 #' @param range Return the range (min and max).
+#' @param quartiles Return the first and third quartiles (25th and 75pth percentiles).
 #' @param include_factors Logical, if \code{TRUE}, factors are included in the
 #'   output, however, only columns for range (first and last factor levels) as
 #'   well as n and missing will contain information.
@@ -46,6 +47,7 @@ describe_distribution.numeric <- function(x,
                                           dispersion = TRUE,
                                           iqr = TRUE,
                                           range = TRUE,
+                                          quartiles = FALSE,
                                           ci = NULL,
                                           iterations = 100,
                                           threshold = .1,
@@ -104,6 +106,16 @@ describe_distribution.numeric <- function(x,
     )
   }
 
+  # Quartiles
+  if (quartiles) {
+    out <- cbind(
+      out,
+      data.frame(
+        Q1 = quantile(x, probs = 0.25, na.rm = TRUE),
+        Q3 = quantile(x, probs = 0.75, na.rm = TRUE)
+      )
+    )
+  }
 
   # Skewness
   out <- cbind(
@@ -145,6 +157,8 @@ describe_distribution.factor <- function(x, dispersion = TRUE, range = TRUE, ...
     IQR = NA,
     Min = levels(x)[1],
     Max = levels(x)[nlevels(x)],
+    Q1 = NA,
+    Q3 = NA,
     Skewness = as.numeric(skewness(x)),
     Kurtosis = as.numeric(kurtosis(x)),
     n = length(x),
@@ -171,6 +185,11 @@ describe_distribution.factor <- function(x, dispersion = TRUE, range = TRUE, ...
   if (!range) {
     out$Min <- NULL
     out$Max <- NULL
+  }
+  
+  if (!quartiles) {
+    out$Q1 <- NULL
+    out$Q3 <- NULL
   }
 
   class(out) <- unique(c("parameters_distribution", "see_parameters_distribution", class(out)))
@@ -195,6 +214,8 @@ describe_distribution.character <- function(x, dispersion = TRUE, range = TRUE, 
     CI_high = NA,
     Min = values[1],
     Max = values[length(values)],
+    Q1 = NA,
+    Q3 = NA,
     Skewness = as.numeric(skewness(x)),
     Kurtosis = as.numeric(kurtosis(x)),
     n = length(x),
@@ -222,6 +243,11 @@ describe_distribution.character <- function(x, dispersion = TRUE, range = TRUE, 
     out$Min <- NULL
     out$Max <- NULL
   }
+  
+  if (!quartiles) {
+    out$Q1 <- NULL
+    out$Q3 <- NULL
+  }
 
   class(out) <- unique(c("parameters_distribution", "see_parameters_distribution", class(out)))
   attr(out, "data") <- x
@@ -237,6 +263,7 @@ describe_distribution.data.frame <- function(x,
                                              dispersion = TRUE,
                                              iqr = TRUE,
                                              range = TRUE,
+                                             quartiles = FALSE,
                                              include_factors = FALSE,
                                              ci = NULL,
                                              iterations = 100,
@@ -250,6 +277,7 @@ describe_distribution.data.frame <- function(x,
         dispersion = dispersion,
         iqr = iqr,
         range = range,
+        quartiles = quartiles,
         ci = ci,
         iterations = iterations,
         threshold = threshold
@@ -278,6 +306,7 @@ describe_distribution.grouped_df <- function(x,
                                              dispersion = TRUE,
                                              iqr = TRUE,
                                              range = TRUE,
+                                             quartiles = FALSE,
                                              include_factors = FALSE,
                                              ci = NULL,
                                              iterations = 100,
@@ -294,6 +323,7 @@ describe_distribution.grouped_df <- function(x,
       dispersion = dispersion,
       iqr = iqr,
       range = range,
+      quartiles = quartiles,
       include_factors = include_factors,
       ci = ci,
       iterations = iterations,
@@ -344,6 +374,7 @@ print.parameters_distribution <- function(x, digits = 2, ...) {
     dispersion = FALSE,
     iqr = FALSE,
     range = FALSE,
+    quartiles = FALSE,
     ci = NULL
   )
   out[[1]]

--- a/R/describe_distribution.R
+++ b/R/describe_distribution.R
@@ -177,14 +177,13 @@ describe_distribution.factor <- function(x, dispersion = TRUE, range = TRUE, ...
     out$CI_low <- NULL
     out$CI_high <- NULL
   }
-  if (is.null(dot.arguments[["iqr"]])) {
+  if (is.null(dot.arguments[["iqr"]]) || isFALSE(dot.arguments[["iqr"]])) {
     out$IQR <- NULL
   }
-  if (is.null(dot.arguments[["quartiles"]])) {
+  if (is.null(dot.arguments[["quartiles"]]) || isFALSE(dot.arguments[["quartiles"]])) {
     out$Q1 <- NULL
     out$Q3 <- NULL
   }
-
   if (!range) {
     out$Min <- NULL
     out$Max <- NULL
@@ -232,14 +231,13 @@ describe_distribution.character <- function(x, dispersion = TRUE, range = TRUE, 
     out$CI_low <- NULL
     out$CI_high <- NULL
   }
-  if (is.null(dot.arguments[["iqr"]])) {
+  if (is.null(dot.arguments[["iqr"]]) || isFALSE(dot.arguments[["iqr"]])) {
     out$IQR <- NULL
   }
-  if (is.null(dot.arguments[["quartiles"]])) {
+  if (is.null(dot.arguments[["quartiles"]]) || isFALSE(dot.arguments[["quartiles"]])) {
     out$Q1 <- NULL
     out$Q3 <- NULL
   }
-
 
   if (!range) {
     out$Min <- NULL

--- a/R/format.R
+++ b/R/format.R
@@ -342,6 +342,12 @@ format.parameters_distribution <- function(x, digits = 2, format = NULL, ci_widt
     colnames(x)[which(colnames(x) == "Min")] <- "Range"
   }
 
+  if (all(c("Q1", "Q3") %in% names(x))) {
+    x$Q1 <- insight::format_ci(x$Q1, x$Q3, ci = NULL, digits = digits, width = ci_width, brackets = ci_brackets)
+    x$Q3 <- NULL
+    colnames(x)[which(colnames(x) == "Q1")] <- "Quartiles"
+  }
+
   if (all(c("CI_low", "CI_high") %in% names(x))) {
     x$CI_low <- insight::format_ci(x$CI_low, x$CI_high, ci = NULL, digits = digits, width = ci_width, brackets = ci_brackets)
     x$CI_high <- NULL

--- a/R/format.R
+++ b/R/format.R
@@ -343,7 +343,7 @@ format.parameters_distribution <- function(x, digits = 2, format = NULL, ci_widt
   }
 
   if (all(c("Q1", "Q3") %in% names(x))) {
-    x$Q1 <- insight::format_ci(x$Q1, x$Q3, ci = NULL, digits = digits, width = ci_width, brackets = ci_brackets)
+    x$Q1 <- insight::format_ci(x$Q1, x$Q3, ci = NULL, digits = digits, width = ci_width, brackets = FALSE)
     x$Q3 <- NULL
     colnames(x)[which(colnames(x) == "Q1")] <- "Quartiles"
   }

--- a/man/describe_distribution.Rd
+++ b/man/describe_distribution.Rd
@@ -15,6 +15,7 @@ describe_distribution(x, ...)
   dispersion = TRUE,
   iqr = TRUE,
   range = TRUE,
+  quartiles = FALSE,
   ci = NULL,
   iterations = 100,
   threshold = 0.1,
@@ -29,6 +30,7 @@ describe_distribution(x, ...)
   dispersion = TRUE,
   iqr = TRUE,
   range = TRUE,
+  quartiles = FALSE,
   include_factors = FALSE,
   ci = NULL,
   iterations = 100,
@@ -49,6 +51,8 @@ describe_distribution(x, ...)
 (based on \code{\link[stats]{IQR}}, using \code{type = 6}).}
 
 \item{range}{Return the range (min and max).}
+
+\item{quartiles}{Return the first and third quartiles (25th and 75pth percentiles).}
 
 \item{ci}{Confidence Interval (CI) level. Default is \code{NULL}, i.e. no
 confidence intervals are computed. If not \code{NULL}, confidence intervals


### PR DESCRIPTION
I really like describe_parameters() but have missed the ability to calculate quartiles (25th and 75th percentiles), so I thought I'd try to add this as an optional (default = FALSE) argument.