### PR TITLE
be backward compatible; exp BF if log

### DIFF
--- a/R/methods_BayesFactor.R
+++ b/R/methods_BayesFactor.R
@@ -92,7 +92,7 @@ model_parameters.BFBayesFactor <- function(model,
     {
       bfm <- as.data.frame(bayestestR::bayesfactor_models(model)[-1, ])
       if (!is.null(bfm$log_BF)) {
-        out$BF <- bfm$log_BF
+        out$BF <- exp(bfm$log_BF)
       } else {
         out$BF <- bfm$BF
       }

--- a/tests/testthat/test-model_parameters.BFBayesFactor.R
+++ b/tests/testthat/test-model_parameters.BFBayesFactor.R
@@ -47,7 +47,7 @@ if (require("testthat") &&
 
     test_that("model_parameters.BFBayesFactor", {
       expect_equal(colnames(mp), c(
-        "Parameter", "Median", "CI", "CI_low", "CI_high", "pd", "ROPE_Percentage",
+        "Parameter", "Median", "MAD", "CI", "CI_low", "CI_high", "pd", "ROPE_Percentage",
         "Prior_Distribution", "Prior_Location", "Prior_Scale", "BF", "Method"
       ))
     })
@@ -61,7 +61,7 @@ if (require("testthat") &&
 
     test_that("model_parameters.BFBayesFactor", {
       expect_equal(colnames(mp), c(
-        "Parameter", "Median", "CI", "CI_low", "CI_high", "pd", "ROPE_Percentage",
+        "Parameter", "Median", "MAD", "CI", "CI_low", "CI_high", "pd", "ROPE_Percentage",
         "Prior_Distribution", "Prior_Location", "Prior_Scale", "Effects",
         "Component", "BF", "Method"
       ))

--- a/tests/testthat/test-model_parameters.BFBayesFactor.R
+++ b/tests/testthat/test-model_parameters.BFBayesFactor.R
@@ -47,8 +47,8 @@ if (require("testthat") &&
 
     test_that("model_parameters.BFBayesFactor", {
       expect_equal(colnames(mp), c(
-        "Parameter", "Median", "MAD", "CI", "CI_low", "CI_high", "pd", "ROPE_Percentage",
-        "Prior_Distribution", "Prior_Location", "Prior_Scale", "BF", "Method"
+        "Parameter", "Median", "CI", "CI_low", "CI_high", "pd", "ROPE_Percentage",
+        "MAD", "Prior_Distribution", "Prior_Location", "Prior_Scale", "BF", "Method"
       ))
     })
 


### PR DESCRIPTION
Since the column name is `BF`, we should be returning raw BF values, not logged values. This will also prevent dependencies like `correlation` and `statsExpressions` from breaking:

``` r
library(BayesFactor)
library(bayestestR)

m <- ttestBF(x = sleep$extra[sleep$group == 1], y = sleep$extra[sleep$group == 2], paired = TRUE)

m
#> Bayes factor analysis
#> --------------
#> [1] Alt., r=0.707 : 17.25888 ±0%
#> 
#> Against denominator:
#>   Null, mu = 0 
#> ---
#> Bayes factor type: BFoneSample, JZS

parameters::parameters(m)
#> Bayesian t-test
#> 
#> Parameter  | Median |         89% CI |     pd | % in ROPE |  MAD |              Prior |    BF
#> ---------------------------------------------------------------------------------------------
#> Difference |   1.42 | [ 0.69,  2.11] | 99.72% |        0% | 0.41 | Cauchy (0 +- 0.71) | 17.26
#> Cohen's D  |  -1.09 | [-1.75, -0.39] | 99.70% |        0% |      |                    |
#> 
#> Using highest density intervals as credible intervals.
```

<sup>Created on 2021-05-14 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>