### PR TITLE
add verbose arg to describe_distribution

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,9 @@
   can be helpful for users who may wish to report ANOVA table in wide format
   (i.e., with numerator and denominator degrees of freedom on the same row).
 
+* `describe_distribution()` gets `verbose` argument to toggle warnings and
+  messages.
+
 # parameters 0.14.0
 
 ## Breaking changes

--- a/R/skewness_kurtosis.R
+++ b/R/skewness_kurtosis.R
@@ -13,6 +13,7 @@
 #'   significantly different from zero.
 #' @param digits Number of decimal places.
 #' @param object An object returned by \code{skewness()} or \code{kurtosis()}.
+#' @param verbose Toggle warnings and messages.
 #' @param ... Arguments passed to or from other methods.
 #'
 #' @details \subsection{Skewness}{
@@ -33,9 +34,15 @@
 #' \subsection{Types of Skewness}{
 #' \code{skewness()} supports three different methods for estimating skewness, as discussed in \cite{Joanes and Gill (1988)}:
 #' \itemize{
-#' \item Type "1" is the "classical" method, which is \code{g1 = (sum((x - mean(x))^3) / n) / (sum((x - mean(x))^2) / n)^1.5}
-#' \item Type "2" first calculates the type-1 skewness, than adjusts the result: \code{G1 = g1 * sqrt(n * (n - 1)) / (n - 2)}. This is what SAS and SPSS usually return
-#' \item Type "3" first calculates the type-1 skewness, than adjusts the result: \code{b1 = g1 * ((1 - 1 / n))^1.5}. This is what Minitab usually returns.
+#' \item Type "1" is the "classical" method, which is \code{g1 = (sum((x -
+#' mean(x))^3) / n) / (sum((x - mean(x))^2) / n)^1.5}
+#'
+#' \item Type "2" first calculates the type-1 skewness, than adjusts the result:
+#' \code{G1 = g1 * sqrt(n * (n - 1)) / (n - 2)}. This is what SAS and SPSS
+#' usually return
+#'
+#' \item Type "3" first calculates the type-1 skewness, than adjusts the result:
+#' \code{b1 = g1 * ((1 - 1 / n))^1.5}. This is what Minitab usually returns.
 #' }
 #' }
 #' \subsection{Kurtosis}{
@@ -46,21 +53,35 @@
 #' tails (\cite{https://en.wikipedia.org/wiki/Kurtosis}).
 #' }
 #' \subsection{Types of Kurtosis}{
-#' \code{kurtosis()} supports three different methods for estimating kurtosis, as discussed in \cite{Joanes and Gill (1988)}:
+#' \code{kurtosis()} supports three different methods for estimating kurtosis,
+#' as discussed in \cite{Joanes and Gill (1988)}:
 #' \itemize{
-#' \item Type "1" is the "classical" method, which is \code{g2 = n * sum((x - mean(x))^4) / (sum((x - mean(x))^2)^2) - 3}.
-#' \item Type "2" first calculates the type-1 kurtosis, than adjusts the result: \code{G2 = ((n + 1) * g2 + 6) * (n - 1)/((n - 2) * (n - 3))}. This is what SAS and SPSS usually return
-#' \item Type "3" first calculates the type-1 kurtosis, than adjusts the result: \code{b2 = (g2 + 3) * (1 - 1 / n)^2 - 3}. This is what Minitab usually returns.
+#' \item Type "1" is the "classical" method, which is \code{g2 = n * sum((x -
+#' mean(x))^4) / (sum((x - mean(x))^2)^2) - 3}.
+#'
+#' \item Type "2" first calculates the type-1 kurtosis, than adjusts the result:
+#' \code{G2 = ((n + 1) * g2 + 6) * (n - 1)/((n - 2) * (n - 3))}. This is what
+#' SAS and SPSS usually return
+#'
+#' \item Type "3" first calculates the type-1 kurtosis, than adjusts the result:
+#' \code{b2 = (g2 + 3) * (1 - 1 / n)^2 - 3}. This is what Minitab usually
+#' returns.
 #' }
 #' }
 #' \subsection{Standard Errors}{
-#' It is recommended to compute empirical (bootstrapped) standard errors (via the \code{iterations} argument) than relying on analytic standard errors (\cite{Wright & Herrington, 2011}).
+#' It is recommended to compute empirical (bootstrapped) standard errors (via
+#' the \code{iterations} argument) than relying on analytic standard errors
+#' (\cite{Wright & Herrington, 2011}).
 #' }
 #'
 #' @references
 #' \itemize{
-#'   \item D. N. Joanes and C. A. Gill (1998). Comparing measures of sample skewness and kurtosis. The Statistician, 47, 183–189.
-#'   \item Wright, D. B., & Herrington, J. A. (2011). Problematic standard errors and confidence intervals for skewness and kurtosis. Behavior research methods, 43(1), 8-17.
+#'   \item D. N. Joanes and C. A. Gill (1998). Comparing measures of sample
+#'   skewness and kurtosis. The Statistician, 47, 183–189.
+#'
+#'   \item Wright, D. B., & Herrington, J. A. (2011). Problematic standard
+#'   errors and confidence intervals for skewness and kurtosis. Behavior
+#'   research methods, 43(1), 8-17.
 #' }
 #'
 #'
@@ -70,7 +91,12 @@
 #' skewness(rnorm(1000))
 #' kurtosis(rnorm(1000))
 #' @export
-skewness <- function(x, na.rm = TRUE, type = "2", iterations = NULL, ...) {
+skewness <- function(x,
+                     na.rm = TRUE,
+                     type = "2",
+                     iterations = NULL,
+                     verbose = TRUE,
+                     ...) {
   UseMethod("skewness")
 }
 
@@ -79,7 +105,12 @@ skewness <- function(x, na.rm = TRUE, type = "2", iterations = NULL, ...) {
 
 
 #' @export
-skewness.numeric <- function(x, na.rm = TRUE, type = "2", iterations = NULL, ...) {
+skewness.numeric <- function(x,
+                             na.rm = TRUE,
+                             type = "2",
+                             iterations = NULL,
+                             verbose = TRUE,
+                             ...) {
   if (na.rm) x <- x[!is.na(x)]
   n <- length(x)
   out <- (sum((x - mean(x))^3) / n) / (sum((x - mean(x))^2) / n)^1.5
@@ -87,7 +118,9 @@ skewness.numeric <- function(x, na.rm = TRUE, type = "2", iterations = NULL, ...
   type <- .check_skewness_type(type)
 
   if (type == "2" && n < 3) {
-    warning(insight::format_message("Need at least 3 complete observations for type-2-skewness. Using 'type=\"1\"' now."), call. = FALSE)
+    if (verbose) {
+      warning(insight::format_message("Need at least 3 complete observations for type-2-skewness. Using 'type=\"1\"' now."), call. = FALSE)
+    }
     type <- "1"
   }
 
@@ -131,13 +164,28 @@ skewness.numeric <- function(x, na.rm = TRUE, type = "2", iterations = NULL, ...
 
 
 #' @export
-skewness.matrix <- function(x, na.rm = TRUE, type = "2", iterations = NULL, ...) {
-  .skewness <- apply(x, 2, skewness, na.rm = na.rm, type = type, iterations = iterations)
+skewness.matrix <- function(x,
+                            na.rm = TRUE,
+                            type = "2",
+                            iterations = NULL,
+                            ...) {
+  .skewness <- apply(
+    x,
+    2,
+    skewness,
+    na.rm = na.rm,
+    type = type,
+    iterations = iterations
+  )
+
   .names <- colnames(x)
+
   if (length(.names) == 0) {
     .names <- paste0("X", seq_len(ncol(x)))
   }
+
   .skewness <- cbind(Parameter = .names, do.call(rbind, .skewness))
+
   class(.skewness) <- unique(c("parameters_skewness", class(.skewness)))
   .skewness
 }
@@ -145,9 +193,20 @@ skewness.matrix <- function(x, na.rm = TRUE, type = "2", iterations = NULL, ...)
 
 
 #' @export
-skewness.data.frame <- function(x, na.rm = TRUE, type = "2", iterations = NULL, ...) {
-  .skewness <- lapply(x, skewness, na.rm = na.rm, type = type, iterations = iterations)
+skewness.data.frame <- function(x,
+                                na.rm = TRUE,
+                                type = "2",
+                                iterations = NULL,
+                                ...) {
+  .skewness <- lapply(x,
+    skewness,
+    na.rm = na.rm,
+    type = type,
+    iterations = iterations
+  )
+
   .skewness <- cbind(Parameter = names(.skewness), do.call(rbind, .skewness))
+
   class(.skewness) <- unique(c("parameters_skewness", class(.skewness)))
   .skewness
 }
@@ -155,14 +214,18 @@ skewness.data.frame <- function(x, na.rm = TRUE, type = "2", iterations = NULL, 
 
 
 #' @export
-skewness.default <- function(x, na.rm = TRUE, type = "2", iterations = NULL, ...) {
-  skewness(.factor_to_numeric(x), na.rm = na.rm, type = type, iterations = iterations)
+skewness.default <- function(x,
+                             na.rm = TRUE,
+                             type = "2",
+                             iterations = NULL,
+                             ...) {
+  skewness(
+    .factor_to_numeric(x),
+    na.rm = na.rm,
+    type = type,
+    iterations = iterations
+  )
 }
-
-
-
-
-
 
 
 
@@ -171,14 +234,23 @@ skewness.default <- function(x, na.rm = TRUE, type = "2", iterations = NULL, ...
 
 #' @rdname skewness
 #' @export
-kurtosis <- function(x, na.rm = TRUE, type = "2", iterations = NULL, ...) {
+kurtosis <- function(x,
+                     na.rm = TRUE,
+                     type = "2",
+                     iterations = NULL,
+                     verbose = TRUE,
+                     ...) {
   UseMethod("kurtosis")
 }
 
 
-
 #' @export
-kurtosis.numeric <- function(x, na.rm = TRUE, type = "2", iterations = NULL, ...) {
+kurtosis.numeric <- function(x,
+                             na.rm = TRUE,
+                             type = "2",
+                             iterations = NULL,
+                             verbose = TRUE,
+                             ...) {
   if (na.rm) x <- x[!is.na(x)]
   n <- length(x)
   out <- n * sum((x - mean(x))^4) / (sum((x - mean(x))^2)^2)
@@ -186,7 +258,9 @@ kurtosis.numeric <- function(x, na.rm = TRUE, type = "2", iterations = NULL, ...
   type <- .check_skewness_type(type)
 
   if (type == "2" && n < 4) {
-    warning(insight::format_message("Need at least 4 complete observations for type-2-kurtosis Using 'type=\"1\"' now."), call. = FALSE)
+    if (verbose) {
+      warning(insight::format_message("Need at least 4 complete observations for type-2-kurtosis Using 'type=\"1\"' now."), call. = FALSE)
+    }
     type <- "1"
   }
 
@@ -205,18 +279,16 @@ kurtosis.numeric <- function(x, na.rm = TRUE, type = "2", iterations = NULL, ...
   )
 
   if (!is.null(iterations)) {
-    if (!requireNamespace("boot", quietly = TRUE)) {
-      warning("Package 'boot' needed for bootstrapping SEs.", call. = FALSE)
-    } else {
-      results <- boot::boot(
-        data = x,
-        statistic = .boot_kurtosis,
-        R = iterations,
-        na.rm = na.rm,
-        type = type
-      )
-      out_se <- stats::sd(results$t, na.rm = TRUE)
-    }
+    insight::check_if_installed("boot")
+
+    results <- boot::boot(
+      data = x,
+      statistic = .boot_kurtosis,
+      R = iterations,
+      na.rm = na.rm,
+      type = type
+    )
+    out_se <- stats::sd(results$t, na.rm = TRUE)
   }
 
   .kurtosis <- data.frame(
@@ -228,10 +300,20 @@ kurtosis.numeric <- function(x, na.rm = TRUE, type = "2", iterations = NULL, ...
 }
 
 
-
 #' @export
-kurtosis.matrix <- function(x, na.rm = TRUE, type = "2", iterations = NULL, ...) {
-  .kurtosis <- apply(x, 2, kurtosis, na.rm = na.rm, type = type, iterations = iterations)
+kurtosis.matrix <- function(x,
+                            na.rm = TRUE,
+                            type = "2",
+                            iterations = NULL,
+                            ...) {
+  .kurtosis <- apply(
+    x,
+    2,
+    kurtosis,
+    na.rm = na.rm,
+    type = type,
+    iterations = iterations
+  )
   .names <- colnames(x)
   if (length(.names) == 0) {
     .names <- paste0("X", seq_len(ncol(x)))
@@ -244,8 +326,17 @@ kurtosis.matrix <- function(x, na.rm = TRUE, type = "2", iterations = NULL, ...)
 
 
 #' @export
-kurtosis.data.frame <- function(x, na.rm = TRUE, type = "2", iterations = NULL, ...) {
-  .kurtosis <- lapply(x, kurtosis, na.rm = na.rm, type = type, iterations = iterations)
+kurtosis.data.frame <- function(x,
+                                na.rm = TRUE,
+                                type = "2",
+                                iterations = NULL,
+                                ...) {
+  .kurtosis <- lapply(x,
+    kurtosis,
+    na.rm = na.rm,
+    type = type,
+    iterations = iterations
+  )
   .kurtosis <- cbind(Parameter = names(.kurtosis), do.call(rbind, .kurtosis))
   class(.kurtosis) <- unique(c("parameters_kurtosis", class(.kurtosis)))
   .kurtosis
@@ -254,12 +345,18 @@ kurtosis.data.frame <- function(x, na.rm = TRUE, type = "2", iterations = NULL, 
 
 
 #' @export
-kurtosis.default <- function(x, na.rm = TRUE, type = "2", iterations = NULL, ...) {
-  kurtosis(.factor_to_numeric(x), na.rm = na.rm, type = type, iterations = iterations)
+kurtosis.default <- function(x,
+                             na.rm = TRUE,
+                             type = "2",
+                             iterations = NULL,
+                             ...) {
+  kurtosis(
+    .factor_to_numeric(x),
+    na.rm = na.rm,
+    type = type,
+    iterations = iterations
+  )
 }
-
-
-
 
 
 # methods -----------------------------------------
@@ -312,12 +409,7 @@ summary.parameters_kurtosis <- function(object, test = FALSE, ...) {
   object
 }
 
-
-
-
-
 # helper ------------------------------------------
-
 
 .check_skewness_type <- function(type) {
   # convenience

--- a/man/describe_distribution.Rd
+++ b/man/describe_distribution.Rd
@@ -19,10 +19,11 @@ describe_distribution(x, ...)
   ci = NULL,
   iterations = 100,
   threshold = 0.1,
+  verbose = TRUE,
   ...
 )
 
-\method{describe_distribution}{factor}(x, dispersion = TRUE, range = TRUE, ...)
+\method{describe_distribution}{factor}(x, dispersion = TRUE, range = TRUE, verbose = TRUE, ...)
 
 \method{describe_distribution}{data.frame}(
   x,
@@ -35,6 +36,7 @@ describe_distribution(x, ...)
   ci = NULL,
   iterations = 100,
   threshold = 0.1,
+  verbose = TRUE,
   ...
 )
 }
@@ -52,7 +54,8 @@ describe_distribution(x, ...)
 
 \item{range}{Return the range (min and max).}
 
-\item{quartiles}{Return the first and third quartiles (25th and 75pth percentiles).}
+\item{quartiles}{Return the first and third quartiles (25th and 75pth
+percentiles).}
 
 \item{ci}{Confidence Interval (CI) level. Default is \code{NULL}, i.e. no
 confidence intervals are computed. If not \code{NULL}, confidence intervals
@@ -64,6 +67,8 @@ the first centrality index (which is typically the median).}
 intervals. Only applies when \code{ci} is not \code{NULL}.}
 
 \item{threshold}{For \code{centrality = "trimmed"} (i.e. trimmed mean), indicates the fraction (0 to 0.5) of observations to be trimmed from each end of the vector before the mean is computed.}
+
+\item{verbose}{Toggle warnings and messages.}
 
 \item{include_factors}{Logical, if \code{TRUE}, factors are included in the
 output, however, only columns for range (first and last factor levels) as

--- a/man/skewness.Rd
+++ b/man/skewness.Rd
@@ -9,9 +9,9 @@
 \alias{summary.parameters_kurtosis}
 \title{Compute Skewness and (Excess) Kurtosis}
 \usage{
-skewness(x, na.rm = TRUE, type = "2", iterations = NULL, ...)
+skewness(x, na.rm = TRUE, type = "2", iterations = NULL, verbose = TRUE, ...)
 
-kurtosis(x, na.rm = TRUE, type = "2", iterations = NULL, ...)
+kurtosis(x, na.rm = TRUE, type = "2", iterations = NULL, verbose = TRUE, ...)
 
 \method{print}{parameters_kurtosis}(x, digits = 3, test = FALSE, ...)
 
@@ -34,6 +34,8 @@ kurtosis(x, na.rm = TRUE, type = "2", iterations = NULL, ...)
 \item{iterations}{The number of bootstrap replicates for computing standard
 errors. If \code{NULL} (default), parametric standard errors are computed.
 See 'Details'.}
+
+\item{verbose}{Toggle warnings and messages.}
 
 \item{...}{Arguments passed to or from other methods.}
 
@@ -69,9 +71,15 @@ for the relationship of skewness and distributions are:
 \subsection{Types of Skewness}{
 \code{skewness()} supports three different methods for estimating skewness, as discussed in \cite{Joanes and Gill (1988)}:
 \itemize{
-\item Type "1" is the "classical" method, which is \code{g1 = (sum((x - mean(x))^3) / n) / (sum((x - mean(x))^2) / n)^1.5}
-\item Type "2" first calculates the type-1 skewness, than adjusts the result: \code{G1 = g1 * sqrt(n * (n - 1)) / (n - 2)}. This is what SAS and SPSS usually return
-\item Type "3" first calculates the type-1 skewness, than adjusts the result: \code{b1 = g1 * ((1 - 1 / n))^1.5}. This is what Minitab usually returns.
+\item Type "1" is the "classical" method, which is \code{g1 = (sum((x -
+mean(x))^3) / n) / (sum((x - mean(x))^2) / n)^1.5}
+
+\item Type "2" first calculates the type-1 skewness, than adjusts the result:
+\code{G1 = g1 * sqrt(n * (n - 1)) / (n - 2)}. This is what SAS and SPSS
+usually return
+
+\item Type "3" first calculates the type-1 skewness, than adjusts the result:
+\code{b1 = g1 * ((1 - 1 / n))^1.5}. This is what Minitab usually returns.
 }
 }
 \subsection{Kurtosis}{
@@ -82,15 +90,25 @@ A kurtosis value below zero indicates a "platykurtic" distribution with \emph{th
 tails (\cite{https://en.wikipedia.org/wiki/Kurtosis}).
 }
 \subsection{Types of Kurtosis}{
-\code{kurtosis()} supports three different methods for estimating kurtosis, as discussed in \cite{Joanes and Gill (1988)}:
+\code{kurtosis()} supports three different methods for estimating kurtosis,
+as discussed in \cite{Joanes and Gill (1988)}:
 \itemize{
-\item Type "1" is the "classical" method, which is \code{g2 = n * sum((x - mean(x))^4) / (sum((x - mean(x))^2)^2) - 3}.
-\item Type "2" first calculates the type-1 kurtosis, than adjusts the result: \code{G2 = ((n + 1) * g2 + 6) * (n - 1)/((n - 2) * (n - 3))}. This is what SAS and SPSS usually return
-\item Type "3" first calculates the type-1 kurtosis, than adjusts the result: \code{b2 = (g2 + 3) * (1 - 1 / n)^2 - 3}. This is what Minitab usually returns.
+\item Type "1" is the "classical" method, which is \code{g2 = n * sum((x -
+mean(x))^4) / (sum((x - mean(x))^2)^2) - 3}.
+
+\item Type "2" first calculates the type-1 kurtosis, than adjusts the result:
+\code{G2 = ((n + 1) * g2 + 6) * (n - 1)/((n - 2) * (n - 3))}. This is what
+SAS and SPSS usually return
+
+\item Type "3" first calculates the type-1 kurtosis, than adjusts the result:
+\code{b2 = (g2 + 3) * (1 - 1 / n)^2 - 3}. This is what Minitab usually
+returns.
 }
 }
 \subsection{Standard Errors}{
-It is recommended to compute empirical (bootstrapped) standard errors (via the \code{iterations} argument) than relying on analytic standard errors (\cite{Wright & Herrington, 2011}).
+It is recommended to compute empirical (bootstrapped) standard errors (via
+the \code{iterations} argument) than relying on analytic standard errors
+(\cite{Wright & Herrington, 2011}).
 }
 }
 \examples{
@@ -99,7 +117,11 @@ kurtosis(rnorm(1000))
 }
 \references{
 \itemize{
-  \item D. N. Joanes and C. A. Gill (1998). Comparing measures of sample skewness and kurtosis. The Statistician, 47, 183–189.
-  \item Wright, D. B., & Herrington, J. A. (2011). Problematic standard errors and confidence intervals for skewness and kurtosis. Behavior research methods, 43(1), 8-17.
+  \item D. N. Joanes and C. A. Gill (1998). Comparing measures of sample
+  skewness and kurtosis. The Statistician, 47, 183–189.
+
+  \item Wright, D. B., & Herrington, J. A. (2011). Problematic standard
+  errors and confidence intervals for skewness and kurtosis. Behavior
+  research methods, 43(1), 8-17.
 }
 }


### PR DESCRIPTION
``` r
library(parameters)
describe_distribution(rnorm(3))
#> Warning: Need at least 4 complete observations for type-2-kurtosis Using
#> 'type="1"' now.
#> Mean |   SD |  IQR |         Range | Skewness | Kurtosis | n | n_Missing
#> ------------------------------------------------------------------------
#> 0.94 | 1.34 | 2.68 | [-0.34, 2.34] |     0.44 |    -1.50 | 3 |         0
describe_distribution(rnorm(3), verbose = FALSE)
#>  Mean |   SD |  IQR |          Range | Skewness | Kurtosis | n | n_Missing
#> --------------------------------------------------------------------------
#> -1.35 | 1.02 | 2.02 | [-2.28, -0.25] |     0.72 |    -1.50 | 3 |         0
```

<sup>Created on 2021-06-06 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>