### PR TITLE
requiet: testthat log readability

### DIFF
--- a/tests/testthat/helper-requiet.R
+++ b/tests/testthat/helper-requiet.R
@@ -1,0 +1,4 @@
+requiet <- function(package) {
+  suppressPackageStartupMessages(
+    require(package, warn.conflicts = FALSE, character.only = TRUE))
+}

--- a/tests/testthat/test-GLMMadaptive.R
+++ b/tests/testthat/test-GLMMadaptive.R
@@ -1,9 +1,9 @@
 .runThisTest <- Sys.getenv("RunAllparametersTests") == "yes"
 
-if (require("testthat") &&
-  require("parameters") &&
-  require("lme4") &&
-  require("GLMMadaptive")) {
+if (requiet("testthat") &&
+  requiet("parameters") &&
+  requiet("lme4") &&
+  requiet("GLMMadaptive")) {
   data("fish")
   data("cbpp")
 
@@ -131,7 +131,7 @@ if (require("testthat") &&
     )
   })
 
-  if (.runThisTest && require("glmmTMB")) {
+  if (.runThisTest && requiet("glmmTMB")) {
     data("Salamanders")
     model <- mixed_model(
       count ~ spp + mined,

--- a/tests/testthat/test-MCMCglmm.R
+++ b/tests/testthat/test-MCMCglmm.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("parameters") &&
-  require("MCMCglmm")) {
+if (requiet("testthat") &&
+  requiet("parameters") &&
+  requiet("MCMCglmm")) {
   data(PlodiaPO)
   set.seed(123)
   m1 <- MCMCglmm(

--- a/tests/testthat/test-PMCMRplus.R
+++ b/tests/testthat/test-PMCMRplus.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("parameters") && require("PMCMRplus")) {
+if (requiet("testthat") && requiet("parameters") && requiet("PMCMRplus")) {
   test_that("model_parameters.PMCMR", {
     set.seed(123)
     mod <- suppressWarnings(kwAllPairsConoverTest(count ~ spray, data = InsectSprays))

--- a/tests/testthat/test-backticks.R
+++ b/tests/testthat/test-backticks.R
@@ -1,7 +1,7 @@
 .runThisTest <- Sys.getenv("RunAllparametersTests") == "yes"
 
 if (.runThisTest) {
-  if (require("testthat") && require("parameters")) {
+  if (requiet("testthat") && requiet("parameters")) {
     data(iris)
     iris$`a m` <<- iris$Species
     iris$`Sepal Width` <<- iris$Sepal.Width

--- a/tests/testthat/test-betareg.R
+++ b/tests/testthat/test-betareg.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("parameters") && require("betareg")) {
+if (requiet("testthat") && requiet("parameters") && requiet("betareg")) {
   data("GasolineYield")
   data("FoodExpenditure")
 

--- a/tests/testthat/test-bootstrap_emmeans.R
+++ b/tests/testthat/test-bootstrap_emmeans.R
@@ -1,6 +1,6 @@
 .runThisTest <- Sys.getenv("RunAllparametersTests") == "yes"
 
-if (.runThisTest && require("testthat") && require("parameters")) {
+if (.runThisTest && requiet("testthat") && requiet("parameters")) {
   test_that("emmeans | lm", {
     skip_if_not_installed("emmeans")
     skip_if_not_installed("boot")

--- a/tests/testthat/test-bracl.R
+++ b/tests/testthat/test-bracl.R
@@ -1,7 +1,7 @@
-if (require("testthat") &&
-  require("parameters") &&
-  require("utils") &&
-  require("brglm2")) {
+if (requiet("testthat") &&
+  requiet("parameters") &&
+  requiet("utils") &&
+  requiet("brglm2")) {
   data("stemcell")
   levels(stemcell$research) <- c("definitly", "alterly", "probably not", "definitely not")
   m1 <- bracl(research ~ as.numeric(religion) + gender, weights = frequency, data = stemcell, type = "ML")

--- a/tests/testthat/test-checks.R
+++ b/tests/testthat/test-checks.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("parameters")) {
+if (requiet("testthat") && requiet("parameters")) {
   data(mtcars)
   test_that("check_factorstructure", {
     x <- check_factorstructure(mtcars)

--- a/tests/testthat/test-ci.R
+++ b/tests/testthat/test-ci.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("lme4") && require("parameters")) {
+if (requiet("testthat") && requiet("lme4") && requiet("parameters")) {
   data(mtcars)
   test_that("ci", {
     model <- lm(mpg ~ wt, data = mtcars)

--- a/tests/testthat/test-compare_parameters.R
+++ b/tests/testthat/test-compare_parameters.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("parameters") && require("insight")) {
+if (requiet("testthat") && requiet("parameters") && requiet("insight")) {
   data(iris)
   m1 <- lm(Sepal.Length ~ Species, data = iris)
   m2 <- lm(Sepal.Length ~ Species * Petal.Length, data = iris)

--- a/tests/testthat/test-coxph.R
+++ b/tests/testthat/test-coxph.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("parameters") && require("survival")) {
+if (requiet("testthat") && requiet("parameters") && requiet("survival")) {
   lung <- subset(lung, subset = ph.ecog %in% 0:2)
   lung$sex <- factor(lung$sex, labels = c("male", "female"))
   lung$ph.ecog <- factor(lung$ph.ecog, labels = c("good", "ok", "limited"))

--- a/tests/testthat/test-emmGrid-df_colname.R
+++ b/tests/testthat/test-emmGrid-df_colname.R
@@ -1,10 +1,10 @@
 .runThisTest <- Sys.getenv("RunAllparametersTests") == "yes"
 
 if (.runThisTest &&
-  require("testthat") &&
-  require("parameters") &&
-  require("emmeans") &&
-  require("lme4")) {
+  requiet("testthat") &&
+  requiet("parameters") &&
+  requiet("emmeans") &&
+  requiet("lme4")) {
   data(sleep)
   data(fiber)
 

--- a/tests/testthat/test-equivalence_test.R
+++ b/tests/testthat/test-equivalence_test.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("parameters")) {
+if (requiet("testthat") && requiet("parameters")) {
   test_that("equivalence_test", {
     data(mtcars)
     m <- lm(mpg ~ gear + wt + cyl + hp, data = mtcars)

--- a/tests/testthat/test-format.R
+++ b/tests/testthat/test-format.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("parameters")) {
+if (requiet("testthat") && requiet("parameters")) {
   test_that("format_order", {
     expect_equal(format_order(2), "second")
     expect_equal(format_order(45), "forty fifth")

--- a/tests/testthat/test-format_model_parameters.R
+++ b/tests/testthat/test-format_model_parameters.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("parameters") && require("splines")) {
+if (requiet("testthat") && requiet("parameters") && requiet("splines")) {
   data(mtcars)
 
   m <- lm(mpg ~ qsec:wt + wt:drat, data = mtcars)

--- a/tests/testthat/test-format_p_adjust.R
+++ b/tests/testthat/test-format_p_adjust.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("parameters")) {
+if (requiet("testthat") && requiet("parameters")) {
   test_that("format_p_adjust", {
     expect_equal(format_p_adjust("holm"), "Holm (1979)")
     expect_equal(format_p_adjust("bonferroni"), "Bonferroni")

--- a/tests/testthat/test-format_parameters.R
+++ b/tests/testthat/test-format_parameters.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("parameters") && require("splines")) {
+if (requiet("testthat") && requiet("parameters") && requiet("splines")) {
   data(iris)
   set.seed(123)
   iris$cat <- sample(LETTERS[1:4], nrow(iris), replace = TRUE)
@@ -217,7 +217,7 @@ if (require("testthat") && require("parameters") && require("splines")) {
   })
 
   test_that("format_parameters-17", {
-    if (require("pscl")) {
+    if (requiet("pscl")) {
       data("bioChemists")
       model <- zeroinfl(art ~ fem + mar + kid5 + ment | kid5 + phd, data = bioChemists)
       fp <- format_parameters(model)

--- a/tests/testthat/test-gam.R
+++ b/tests/testthat/test-gam.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("parameters") &&
-  suppressPackageStartupMessages(require("mgcv", quietly = TRUE))) {
+if (requiet("testthat") &&
+  requiet("parameters") &&
+  requiet("mgcv")) {
   set.seed(123)
   dat <- gamSim(1, n = 400, dist = "normal", scale = 2)
   m1 <- mgcv::gam(y ~ s(x0) + s(x1) + s(x2) + s(x3), data = dat)

--- a/tests/testthat/test-gamm.R
+++ b/tests/testthat/test-gamm.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("parameters") &&
-  suppressPackageStartupMessages(require("mgcv", quietly = TRUE))) {
+if (requiet("testthat") &&
+  requiet("parameters") &&
+  requiet("mgcv")) {
   set.seed(123)
   dat <- gamSim(6, n = 200, scale = .2, dist = "poisson")
   m1 <-

--- a/tests/testthat/test-gee.R
+++ b/tests/testthat/test-gee.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("parameters") &&
-  require("gee")) {
+if (requiet("testthat") &&
+  requiet("parameters") &&
+  requiet("gee")) {
   data(warpbreaks)
   m1 <- gee(breaks ~ tension, id = wool, data = warpbreaks)
 

--- a/tests/testthat/test-geeglm.R
+++ b/tests/testthat/test-geeglm.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("parameters") && require("geepack")) {
+if (requiet("testthat") && requiet("parameters") && requiet("geepack")) {
   data(warpbreaks)
   m1 <-
     geeglm(

--- a/tests/testthat/test-get_scores.R
+++ b/tests/testthat/test-get_scores.R
@@ -1,7 +1,7 @@
 .runThisTest <- Sys.getenv("RunAllparametersTests") == "yes"
 
 if (.runThisTest) {
-  if (require("testthat") && require("parameters") && require("psych")) {
+  if (requiet("testthat") && requiet("parameters") && requiet("psych")) {
     data(mtcars)
     pca <- principal_components(mtcars[, 1:7], n = 2, rotation = "varimax")
     scores <- get_scores(pca)

--- a/tests/testthat/test-glmer.R
+++ b/tests/testthat/test-glmer.R
@@ -1,9 +1,9 @@
 .runThisTest <- Sys.getenv("RunAllparametersTests") == "yes"
 
 if (.runThisTest &&
-  require("testthat") &&
-  require("parameters") &&
-  require("lme4")) {
+  requiet("testthat") &&
+  requiet("parameters") &&
+  requiet("lme4")) {
   data("cbpp")
   set.seed(123)
   model <- glmer(

--- a/tests/testthat/test-glmmTMB-2.R
+++ b/tests/testthat/test-glmmTMB-2.R
@@ -1,6 +1,6 @@
 .runThisTest <- Sys.getenv("RunAllparametersTests") == "yes"
 
-if (.runThisTest && require("testthat") && require("parameters") && require("glmmTMB")) {
+if (.runThisTest && requiet("testthat") && requiet("parameters") && requiet("glmmTMB")) {
   data(Salamanders)
   model <- suppressWarnings(glmmTMB(
     count ~ spp + mined + spp * mined,

--- a/tests/testthat/test-glmmTMB.R
+++ b/tests/testthat/test-glmmTMB.R
@@ -1,9 +1,9 @@
 .runThisTest <- Sys.getenv("RunAllparametersTests") == "yes"
 
 if (.runThisTest &&
-  require("testthat") &&
-  require("parameters") &&
-  require("glmmTMB")) {
+  requiet("testthat") &&
+  requiet("parameters") &&
+  requiet("glmmTMB")) {
   data("fish")
   data("Salamanders")
 

--- a/tests/testthat/test-gls.R
+++ b/tests/testthat/test-gls.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("parameters") &&
-  require("nlme")) {
+if (requiet("testthat") &&
+  requiet("parameters") &&
+  requiet("nlme")) {
   data(Ovary)
   m1 <- gls(follicles ~ sin(2 * pi * Time) + cos(2 * pi * Time),
     data = Ovary,

--- a/tests/testthat/test-ivreg.R
+++ b/tests/testthat/test-ivreg.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("parameters") &&
-  require("AER")) {
+if (requiet("testthat") &&
+  requiet("parameters") &&
+  requiet("AER")) {
   data(CigarettesSW)
   CigarettesSW$rprice <- with(CigarettesSW, price / cpi)
   CigarettesSW$rincome <- with(CigarettesSW, income / population / cpi)

--- a/tests/testthat/test-lavaan.R
+++ b/tests/testthat/test-lavaan.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("parameters") && require("lavaan")) {
+if (requiet("testthat") && requiet("parameters") && requiet("lavaan")) {
   model <- "
     # measurement model
       ind60 =~ x1 + x2 + x3

--- a/tests/testthat/test-lme.R
+++ b/tests/testthat/test-lme.R
@@ -1,8 +1,8 @@
-if (require("testthat") &&
-  require("parameters") &&
-  require("nlme") &&
-  require("lme4") &&
-  require("insight")) {
+if (requiet("testthat") &&
+  requiet("parameters") &&
+  requiet("nlme") &&
+  requiet("lme4") &&
+  requiet("insight")) {
   data("sleepstudy")
   m1 <- nlme::lme(Reaction ~ Days,
     random = ~ 1 + Days | Subject,

--- a/tests/testthat/test-lmerTest.R
+++ b/tests/testthat/test-lmerTest.R
@@ -1,6 +1,6 @@
 .runThisTest <- Sys.getenv("RunAllparametersTests") == "yes"
 
-if (.runThisTest && require("testthat") && require("parameters") && require("lmerTest") && require("pbkrtest")) {
+if (.runThisTest && requiet("testthat") && requiet("parameters") && requiet("lmerTest") && requiet("pbkrtest")) {
   data("carrots", package = "lmerTest")
   m1 <- lmerTest::lmer(Preference ~ sens2 + Homesize + (1 + sens2 | Consumer), data = carrots)
 

--- a/tests/testthat/test-mira.R
+++ b/tests/testthat/test-mira.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("parameters") &&
-  require("mice")) {
+if (requiet("testthat") &&
+  requiet("parameters") &&
+  requiet("mice")) {
   data("nhanes2")
   imp <- mice(nhanes2, printFlag = FALSE)
   fit <- with(data = imp, exp = lm(bmi ~ age + hyp + chl))

--- a/tests/testthat/test-mlm.R
+++ b/tests/testthat/test-mlm.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("parameters") && getRversion() >= "3.6.0") {
+if (requiet("testthat") && requiet("parameters") && getRversion() >= "3.6.0") {
   set.seed(123)
   mod <- lm(formula = cbind(mpg, disp) ~ wt, data = mtcars)
   mp <- model_parameters(mod)

--- a/tests/testthat/test-model_parameters.BFBayesFactor.R
+++ b/tests/testthat/test-model_parameters.BFBayesFactor.R
@@ -1,7 +1,7 @@
-if (require("testthat") &&
-  require("parameters") &&
-  suppressPackageStartupMessages(require("BayesFactor", quietly = TRUE)) &&
-  require("logspline") &&
+if (requiet("testthat") &&
+  requiet("parameters") &&
+  requiet("BayesFactor") &&
+  requiet("logspline") &&
   getRversion() >= "3.6") {
   .runThisTest <- Sys.getenv("RunAllparametersTests") == "yes"
 

--- a/tests/testthat/test-model_parameters.afex_aov.R
+++ b/tests/testthat/test-model_parameters.afex_aov.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("parameters") &&
-  suppressPackageStartupMessages(require("afex", quietly = TRUE))) {
+if (requiet("testthat") &&
+  requiet("parameters") &&
+  requiet("afex")) {
   data(obk.long, package = "afex")
   m_between <- suppressWarnings(aov_car(value ~ treatment * gender + Error(id), data = obk.long))
   m_within <- suppressWarnings(aov_car(value ~ Error(id / (phase * hour)), data = obk.long))

--- a/tests/testthat/test-model_parameters.anova.R
+++ b/tests/testthat/test-model_parameters.anova.R
@@ -1,6 +1,6 @@
 .runThisTest <- Sys.getenv("RunAllparametersTests") == "yes"
 
-if (.runThisTest && require("insight") && require("testthat") && require("parameters")) {
+if (.runThisTest && requiet("insight") && requiet("testthat") && requiet("parameters")) {
   data(mtcars)
   m <- glm(am ~ mpg + hp + factor(cyl),
     data = mtcars, family = binomial()
@@ -32,7 +32,7 @@ if (.runThisTest && require("insight") && require("testthat") && require("parame
     )
   })
 
-  if (require("car")) {
+  if (requiet("car")) {
     a <- car::Anova(m, type = 3, test.statistic = "F")
     mp <- model_parameters(a)
 
@@ -70,7 +70,7 @@ if (.runThisTest && require("insight") && require("testthat") && require("parame
     })
 
 
-    if (require("MASS")) {
+    if (requiet("MASS")) {
       data(housing)
       m <- polr(Sat ~ Infl + Type + Cont, weights = Freq, data = housing)
       a <- car::Anova(m)
@@ -83,7 +83,7 @@ if (.runThisTest && require("insight") && require("testthat") && require("parame
     }
   }
 
-  if (require("lme4") && require("effectsize") && utils::packageVersion("effectsize") > "0.4.3") {
+  if (requiet("lme4") && requiet("effectsize") && utils::packageVersion("effectsize") > "0.4.3") {
     data(iris)
     df <- iris
     df$Sepal.Big <- ifelse(df$Sepal.Width >= 3, "Yes", "No")
@@ -115,7 +115,7 @@ if (.runThisTest && require("insight") && require("testthat") && require("parame
 
 # XXX -----
 
-if (.runThisTest && require("parameters") && require("testthat")) {
+if (.runThisTest && requiet("parameters") && requiet("testthat")) {
   test_that("anova type | lm", {
     m <- lm(mpg ~ factor(cyl) * hp + disp, mtcars)
 

--- a/tests/testthat/test-model_parameters.aov.R
+++ b/tests/testthat/test-model_parameters.aov.R
@@ -1,7 +1,7 @@
 .runThisTest <- Sys.getenv("RunAllparametersTests") == "yes"
 
 if (.runThisTest) {
-  if (require("insight") && require("testthat") && require("lme4") && require("parameters")) {
+  if (requiet("insight") && requiet("testthat") && requiet("lme4") && requiet("parameters")) {
     if (requireNamespace("effectsize")) {
       unloadNamespace("afex")
       unloadNamespace("lmerTest")

--- a/tests/testthat/test-model_parameters.aov_es_ci.R
+++ b/tests/testthat/test-model_parameters.aov_es_ci.R
@@ -1,4 +1,4 @@
-if (require("insight") && require("effectsize") && require("testthat") && require("lme4") && require("parameters")) {
+if (requiet("insight") && requiet("effectsize") && requiet("testthat") && requiet("lme4") && requiet("parameters")) {
   unloadNamespace("afex")
   unloadNamespace("lmerTest")
   data(iris)
@@ -78,7 +78,7 @@ if (require("insight") && require("effectsize") && require("testthat") && requir
 
   # car anova ---------------------------------
 
-  if (require("car")) {
+  if (requiet("car")) {
     set.seed(123)
     data(Moore)
     model <-
@@ -131,7 +131,7 @@ if (require("insight") && require("effectsize") && require("testthat") && requir
 
   # stricter tests ---------------------------------------------------------
 
-  if (require("car") && require("gam")) {
+  if (requiet("car") && requiet("gam")) {
 
     # aov ------------------------------------------------
 

--- a/tests/testthat/test-model_parameters.blmerMod.R
+++ b/tests/testthat/test-model_parameters.blmerMod.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("parameters") && require("blme")) {
+if (requiet("testthat") && requiet("parameters") && requiet("blme")) {
   data(sleepstudy)
   set.seed(123)
   model <- blmer(Reaction ~ Days + (1 + Days | Subject), data = sleepstudy, cov.prior = NULL)

--- a/tests/testthat/test-model_parameters.cgam.R
+++ b/tests/testthat/test-model_parameters.cgam.R
@@ -1,6 +1,6 @@
 .runThisTest <- Sys.getenv("RunAllparametersTests") == "yes"
 
-if (.runThisTest && require("testthat") && require("cgam")) {
+if (.runThisTest && requiet("testthat") && requiet("cgam")) {
   test_that("model_parameters - cgam", {
     # cgam -----------------------
 

--- a/tests/testthat/test-model_parameters.cpglmm.R
+++ b/tests/testthat/test-model_parameters.cpglmm.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight") && require("parameters") && require("cplm")) {
+if (requiet("testthat") && requiet("insight") && requiet("parameters") && requiet("cplm")) {
   data("FineRoot")
   model <- cpglmm(RLD ~ Stock + Spacing + (1 | Plant), data = FineRoot)
 

--- a/tests/testthat/test-model_parameters.efa_cfa.R
+++ b/tests/testthat/test-model_parameters.efa_cfa.R
@@ -8,12 +8,12 @@ linux <- tryCatch({
 })
 
 
-if (require("testthat") &&
-  require("parameters") &&
-  require("psych") &&
-  suppressPackageStartupMessages(require("lavaan", quietly = TRUE)) &&
-  suppressPackageStartupMessages(require("BayesFM", quietly = TRUE)) &&
-  require("FactoMineR")) {
+if (requiet("testthat") &&
+  requiet("parameters") &&
+  requiet("psych") &&
+  requiet("lavaan") &&
+  requiet("BayesFM") &&
+  requiet("FactoMineR")) {
   test_that("principal_components", {
     set.seed(333)
 

--- a/tests/testthat/test-model_parameters.gam.R
+++ b/tests/testthat/test-model_parameters.gam.R
@@ -1,7 +1,7 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("parameters") &&
-  suppressPackageStartupMessages(require("mgcv", quietly = TRUE))) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("parameters") &&
+  requiet("mgcv")) {
   set.seed(123)
   model <-
     mgcv::gam(

--- a/tests/testthat/test-model_parameters.glht.R
+++ b/tests/testthat/test-model_parameters.glht.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight") && require("parameters") && require("multcomp")) {
+if (requiet("testthat") && requiet("insight") && requiet("parameters") && requiet("multcomp")) {
   set.seed(123)
   lmod <- lm(Fertility ~ ., data = swiss)
   model <- glht(

--- a/tests/testthat/test-model_parameters.glm.R
+++ b/tests/testthat/test-model_parameters.glm.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("parameters") && require("boot")) {
+if (requiet("testthat") && requiet("parameters") && requiet("boot")) {
   data(mtcars)
   test_that("model_parameters.lm", {
     model <- lm(mpg ~ wt, data = mtcars)

--- a/tests/testthat/test-model_parameters.htest.R
+++ b/tests/testthat/test-model_parameters.htest.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("parameters") && require("effectsize") && utils::packageVersion("effectsize") > "0.4.5") {
+if (requiet("testthat") && requiet("parameters") && requiet("effectsize") && utils::packageVersion("effectsize") > "0.4.5") {
   test_that("model_parameters.htest", {
     params <- model_parameters(cor.test(mtcars$mpg, mtcars$cyl, method = "pearson"))
     expect_equal(

--- a/tests/testthat/test-model_parameters.hurdle.R
+++ b/tests/testthat/test-model_parameters.hurdle.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("pscl") && require("parameters")) {
+if (requiet("testthat") && requiet("pscl") && requiet("parameters")) {
   set.seed(123)
   data("bioChemists", package = "pscl")
   model <- hurdle(formula = art ~ ., data = bioChemists, zero = "geometric")

--- a/tests/testthat/test-model_parameters.lme.R
+++ b/tests/testthat/test-model_parameters.lme.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight") && require("parameters") && require("nlme") && require("lme4")) {
+if (requiet("testthat") && requiet("insight") && requiet("parameters") && requiet("nlme") && requiet("lme4")) {
   data("sleepstudy")
   model <- lme(Reaction ~ Days,
     random = ~ 1 + Days | Subject,

--- a/tests/testthat/test-model_parameters.lqmm.R
+++ b/tests/testthat/test-model_parameters.lqmm.R
@@ -1,6 +1,6 @@
 .runThisTest <- Sys.getenv("RunAllparametersTests") == "yes"
 
-if (FALSE && require("testthat") && require("lqmm") && require("parameters")) {
+if (FALSE && requiet("testthat") && requiet("lqmm") && requiet("parameters")) {
   # lqm -----------------------
 
   test_that("model_parameters - lqm", {

--- a/tests/testthat/test-model_parameters.maov.R
+++ b/tests/testthat/test-model_parameters.maov.R
@@ -1,4 +1,4 @@
-if (require("insight") && require("testthat") && require("parameters")) {
+if (requiet("insight") && requiet("testthat") && requiet("parameters")) {
   fit <- lm(cbind(mpg, disp, hp) ~ factor(cyl), data = mtcars)
   m <- aov(fit)
   mp <- model_parameters(m)

--- a/tests/testthat/test-model_parameters.mediate.R
+++ b/tests/testthat/test-model_parameters.mediate.R
@@ -1,6 +1,6 @@
 .runThisTest <- Sys.getenv("RunAllparametersTests") == "yes"
 
-if (require("testthat") && require("parameters") && require("mediation") && require("MASS")) {
+if (requiet("testthat") && requiet("parameters") && requiet("mediation") && requiet("MASS")) {
   data(jobs)
   b <- lm(job_seek ~ treat + econ_hard + sex + age, data = jobs)
   c <- lm(depress2 ~ treat + job_seek + econ_hard + sex + age, data = jobs)

--- a/tests/testthat/test-model_parameters.metaBMA.R
+++ b/tests/testthat/test-model_parameters.metaBMA.R
@@ -1,7 +1,7 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("parameters") &&
-  suppressPackageStartupMessages(require("metaBMA", quietly = TRUE)) &&
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("parameters") &&
+  requiet("metaBMA") &&
   getRversion() >= "3.6.0") {
   data(towels)
 

--- a/tests/testthat/test-model_parameters.metafor.R
+++ b/tests/testthat/test-model_parameters.metafor.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight") && require("parameters") && require("metafor")) {
+if (requiet("testthat") && requiet("insight") && requiet("parameters") && requiet("metafor")) {
   test <- data.frame(
     estimate = c(0.111, 0.245, 0.8, 1.1, 0.03),
     std.error = c(0.05, 0.111, 0.001, 0.2, 0.01)

--- a/tests/testthat/test-model_parameters.mfx.R
+++ b/tests/testthat/test-model_parameters.mfx.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight") && require("parameters") && require("mfx")) {
+if (requiet("testthat") && requiet("insight") && requiet("parameters") && requiet("mfx")) {
   set.seed(12345)
   n <- 1000
   x <- rnorm(n)

--- a/tests/testthat/test-model_parameters.mixed.R
+++ b/tests/testthat/test-model_parameters.mixed.R
@@ -1,9 +1,9 @@
 .runThisTest <- Sys.getenv("RunAllparametersTests") == "yes"
 
 if (.runThisTest &&
-  require("testthat") &&
-  require("parameters") &&
-  require("lme4")) {
+  requiet("testthat") &&
+  requiet("parameters") &&
+  requiet("lme4")) {
   data(mtcars)
   m1 <- lme4::lmer(wt ~ cyl + (1 | gear), data = mtcars)
   m2 <- lme4::glmer(vs ~ cyl + (1 | gear), data = mtcars, family = "binomial")

--- a/tests/testthat/test-model_parameters.mle2.R
+++ b/tests/testthat/test-model_parameters.mle2.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("parameters") && require("bbmle")) {
+if (requiet("testthat") && requiet("parameters") && requiet("bbmle")) {
   x <- 0:10
   y <- c(26, 17, 13, 12, 20, 5, 9, 8, 5, 4, 8)
   d <- data.frame(x, y)

--- a/tests/testthat/test-model_parameters.pairwise.htest.R
+++ b/tests/testthat/test-model_parameters.pairwise.htest.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("parameters")) {
+if (requiet("testthat") && requiet("parameters")) {
   test_that("model_parameters.pairwise.htest", {
     data(airquality)
     airquality$Month <- factor(airquality$Month, labels = month.abb[5:9])

--- a/tests/testthat/test-model_parameters.truncreg.R
+++ b/tests/testthat/test-model_parameters.truncreg.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("truncreg") && require("survival") && require("parameters")) {
+if (requiet("testthat") && requiet("truncreg") && requiet("survival") && requiet("parameters")) {
   set.seed(123)
   data("tobin", package = "survival")
 

--- a/tests/testthat/test-model_parameters.vgam.R
+++ b/tests/testthat/test-model_parameters.vgam.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("VGAM") && require("parameters")) {
+if (requiet("testthat") && requiet("VGAM") && requiet("parameters")) {
   data("pneumo")
   data("hunua")
 

--- a/tests/testthat/test-model_parameters_df_method.R
+++ b/tests/testthat/test-model_parameters_df_method.R
@@ -1,8 +1,8 @@
-if (require("testthat") &&
-  require("parameters") &&
-  require("lmerTest") &&
-  require("pbkrtest") &&
-  require("lme4")) {
+if (requiet("testthat") &&
+  requiet("parameters") &&
+  requiet("lmerTest") &&
+  requiet("pbkrtest") &&
+  requiet("lme4")) {
   data("mtcars")
   mtcars$cyl <- as.factor(mtcars$cyl)
   model <- suppressMessages(lme4::lmer(mpg ~ as.factor(gear) * hp + as.factor(am) + wt + (1 | cyl), data = mtcars))

--- a/tests/testthat/test-model_parameters_labels.R
+++ b/tests/testthat/test-model_parameters_labels.R
@@ -1,4 +1,4 @@
-if (require("insight") && require("testthat") && require("parameters") && require("lme4")) {
+if (requiet("insight") && requiet("testthat") && requiet("parameters") && requiet("lme4")) {
   test_that("model_parameters_labels", {
     data(mtcars)
     mtcars$am <- as.factor(mtcars$am)

--- a/tests/testthat/test-model_parameters_mixed_coeforder.R
+++ b/tests/testthat/test-model_parameters_mixed_coeforder.R
@@ -1,4 +1,4 @@
-if (require("lme4") && require("testthat") && require("parameters")) {
+if (requiet("lme4") && requiet("testthat") && requiet("parameters")) {
   set.seed(1)
   dat <- data.frame(
     TST.diff = runif(100, 0, 100),

--- a/tests/testthat/test-model_parameters_robust.R
+++ b/tests/testthat/test-model_parameters_robust.R
@@ -1,8 +1,8 @@
-if (require("testthat") &&
-  require("parameters") &&
-  require("sandwich") &&
-  require("clubSandwich") &&
-  require("effectsize")) {
+if (requiet("testthat") &&
+  requiet("parameters") &&
+  requiet("sandwich") &&
+  requiet("clubSandwich") &&
+  requiet("effectsize")) {
   data(mtcars)
   mtcars$am <- as.factor(mtcars$am)
   model <- lm(mpg ~ wt * am + cyl + gear, data = mtcars)

--- a/tests/testthat/test-model_parameters_std.R
+++ b/tests/testthat/test-model_parameters_std.R
@@ -1,10 +1,10 @@
 .runThisTest <- Sys.getenv("RunAllparametersTests") == "yes"
 
 if (.runThisTest) {
-  if (require("testthat") &&
-    require("parameters") &&
-    require("effectsize") &&
-    require("insight")) {
+  if (requiet("testthat") &&
+    requiet("parameters") &&
+    requiet("effectsize") &&
+    requiet("insight")) {
     data(mtcars)
     mtcars$am <- as.factor(mtcars$am)
     model <- lm(mpg ~ wt * am, data = mtcars)

--- a/tests/testthat/test-model_parameters_std_mixed.R
+++ b/tests/testthat/test-model_parameters_std_mixed.R
@@ -1,10 +1,10 @@
 .runThisTest <- Sys.getenv("RunAllparametersTests") == "yes"
 
 if (.runThisTest &&
-  require("testthat") &&
-  require("parameters") &&
-  require("effectsize") &&
-  require("lme4")) {
+  requiet("testthat") &&
+  requiet("parameters") &&
+  requiet("effectsize") &&
+  requiet("lme4")) {
   data(iris)
   set.seed(1234)
   iris$grp <- as.factor(sample(1:3, nrow(iris), replace = TRUE))
@@ -68,7 +68,7 @@ if (.runThisTest &&
     expect_equal(params$CI_high, c(0, 0.85424, 0.42299, 0.4659, 2.01759, -0.18572, -0.00492), tolerance = 1e-3)
   })
 
-  if (require("clubSandwich")) {
+  if (requiet("clubSandwich")) {
     test_that("model_parameters, standardize-refit robust", {
       params <- model_parameters(model, standardize = "refit", robust = TRUE, vcov_estimation = "CR", vcov_type = "CR1", vcov_args = list(cluster = iris$grp), verbose = FALSE)
       expect_equal(c(nrow(params), ncol(params)), c(7, 10))

--- a/tests/testthat/test-n_factors.R
+++ b/tests/testthat/test-n_factors.R
@@ -1,11 +1,11 @@
 .runThisTest <- Sys.getenv("RunAllparametersTests") == "yes"
 
 if (.runThisTest &&
-  require("testthat") &&
-  require("parameters") &&
-  suppressPackageStartupMessages(require("nFactors", quietly = TRUE)) &&
-  suppressPackageStartupMessages(require("EGAnet", quietly = TRUE)) &&
-  require("psych")) {
+  requiet("testthat") &&
+  requiet("parameters") &&
+  requiet("nFactors") &&
+  requiet("EGAnet") &&
+  requiet("psych")) {
   test_that("n_factors", {
     set.seed(333)
     x <- n_factors(mtcars[, 1:4])

--- a/tests/testthat/test-p_adjust.R
+++ b/tests/testthat/test-p_adjust.R
@@ -1,6 +1,6 @@
 .runThisTest <- Sys.getenv("RunAllparametersTests") == "yes"
 
-if (.runThisTest && require("testthat") && require("parameters")) {
+if (.runThisTest && requiet("testthat") && requiet("parameters")) {
   data(mtcars)
   model <- lm(mpg ~ wt * cyl + am + log(hp), data = mtcars)
 
@@ -13,7 +13,7 @@ if (.runThisTest && require("testthat") && require("parameters")) {
     expect_equal(mp$p, c(0, 0.01824, 0.16588, 1, 0.06411, 0.13869), tolerance = 1e-3)
   })
 
-  if (require("emmeans")) {
+  if (requiet("emmeans")) {
     data(iris)
     m <- pairs(emmeans(aov(Sepal.Width ~ Species, data = iris), ~Species))
     test_that("model_parameters, emmeans, p-adjust", {

--- a/tests/testthat/test-p_value.R
+++ b/tests/testthat/test-p_value.R
@@ -1,10 +1,10 @@
 .runThisTest <- Sys.getenv("RunAllparametersTests") == "yes"
 
 if (.runThisTest) {
-  if (require("testthat") &&
-    require("parameters") &&
-    require("lme4") &&
-    require("insight")) {
+  if (requiet("testthat") &&
+    requiet("parameters") &&
+    requiet("lme4") &&
+    requiet("insight")) {
     data(mtcars)
     test_that("p_value", {
       # h-tests

--- a/tests/testthat/test-panelr.R
+++ b/tests/testthat/test-panelr.R
@@ -1,9 +1,9 @@
 .runThisTest <- Sys.getenv("RunAllparametersTests") == "yes"
 
 if (.runThisTest &&
-  require("testthat") &&
-  require("parameters") &&
-  require("panelr")) {
+  requiet("testthat") &&
+  requiet("parameters") &&
+  requiet("panelr")) {
   data("WageData")
   wages <- panel_data(WageData, id = id, wave = t)
   m1 <- wbm(lwage ~ lag(union) + wks | blk + fem | blk * lag(union), data = wages)

--- a/tests/testthat/test-parameters_selection.R
+++ b/tests/testthat/test-parameters_selection.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("parameters")) {
+if (requiet("testthat") && requiet("parameters")) {
   test_that("select_parameters", {
     model <- lm(mpg ~ ., data = mtcars)
     x <- select_parameters(model)

--- a/tests/testthat/test-parameters_table.R
+++ b/tests/testthat/test-parameters_table.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("parameters") && require("insight") && require("effectsize") && require("lme4")) {
+if (requiet("testthat") && requiet("parameters") && requiet("insight") && requiet("effectsize") && requiet("lme4")) {
   test_that("parameters_table 1", {
     x <- model_parameters(lm(Sepal.Length ~ Species, data = iris), standardize = "refit")
     tab <- format_table(x)

--- a/tests/testthat/test-parameters_type-2.R
+++ b/tests/testthat/test-parameters_type-2.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("parameters")) {
+if (requiet("testthat") && requiet("parameters")) {
   data(iris)
   dat <- iris
   m <- lm(Sepal.Length ~ Species, data = dat)

--- a/tests/testthat/test-parameters_type.R
+++ b/tests/testthat/test-parameters_type.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("parameters")) {
+if (requiet("testthat") && requiet("parameters")) {
   test_that("parameters_type-1", {
     m0 <- lm(mpg ~ am * cyl, mtcars)
     m1 <- lm(mpg ~ am * scale(cyl), mtcars)

--- a/tests/testthat/test-pca.R
+++ b/tests/testthat/test-pca.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("parameters") && require("psych") && require("nFactors")) {
+if (requiet("testthat") && requiet("parameters") && requiet("psych") && requiet("nFactors")) {
   test_that("principal_components", {
     x <- parameters::principal_components(mtcars[, 1:7], rotation = "varimax")
 

--- a/tests/testthat/test-plm.R
+++ b/tests/testthat/test-plm.R
@@ -1,7 +1,7 @@
-if (require("testthat") &&
-  require("parameters") &&
-  require("stats") &&
-  require("plm") &&
+if (requiet("testthat") &&
+  requiet("parameters") &&
+  requiet("stats") &&
+  requiet("plm") &&
   getRversion() > "3.5") {
   data(Crime)
   data("Produc", package = "plm")

--- a/tests/testthat/test-quantreg.R
+++ b/tests/testthat/test-quantreg.R
@@ -1,11 +1,11 @@
 .runThisTest <- Sys.getenv("RunAllparametersTests") == "yes"
 
 if (.runThisTest &&
-  require("testthat") &&
-  require("parameters") &&
-  require("tripack") &&
-  require("insight") &&
-  require("quantreg")) {
+  requiet("testthat") &&
+  requiet("parameters") &&
+  requiet("tripack") &&
+  requiet("insight") &&
+  requiet("quantreg")) {
 
   # rqss ---------
 

--- a/tests/testthat/test-rank_deficienty.R
+++ b/tests/testthat/test-rank_deficienty.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("parameters")) {
+if (requiet("testthat") && requiet("parameters")) {
   set.seed(123)
   data(mtcars)
   model <-

--- a/tests/testthat/test-rstanarm.R
+++ b/tests/testthat/test-rstanarm.R
@@ -15,9 +15,9 @@ osx <- tryCatch(
 )
 
 if (.runThisTest && !osx &&
-  require("testthat") &&
-  require("parameters") &&
-  suppressPackageStartupMessages(require("rstanarm", quietly = TRUE))) {
+  requiet("testthat") &&
+  requiet("parameters") &&
+  requiet("rstanarm")) {
   data(mtcars)
   set.seed(123)
   model <- stan_glm(

--- a/tests/testthat/test-se_ml1R.R
+++ b/tests/testthat/test-se_ml1R.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("parameters") && require("lme4")) {
+if (requiet("testthat") && requiet("parameters") && requiet("lme4")) {
   data(iris)
   model <- lmer(Petal.Length ~ Sepal.Length + (1 | Species), data = iris)
   test_that("se_ml1", {

--- a/tests/testthat/test-tobit.R
+++ b/tests/testthat/test-tobit.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("parameters") &&
-  require("AER")) {
+if (requiet("testthat") &&
+  requiet("parameters") &&
+  requiet("AER")) {
   data("Affairs", package = "AER")
   m1 <- AER::tobit(
     affairs ~ age + yearsmarried + religiousness + occupation + rating,

--- a/tests/testthat/test-wrs2.R
+++ b/tests/testthat/test-wrs2.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("WRS2") && packageVersion("WRS2") >= "1.1.3" && getRversion() >= "3.6.0") {
+if (requiet("testthat") && requiet("WRS2") && packageVersion("WRS2") >= "1.1.3" && getRversion() >= "3.6.0") {
 
   # model_parameters.t1way ---------------------------------------------------
 

--- a/tests/testthat/test-zeroinfl.R
+++ b/tests/testthat/test-zeroinfl.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("parameters") &&
-  require("pscl")) {
+if (requiet("testthat") &&
+  requiet("parameters") &&
+  requiet("pscl")) {
   data("bioChemists")
   m1 <- zeroinfl(art ~ fem + mar + kid5 + ment | kid5 + phd, data = bioChemists)
 


### PR DESCRIPTION
Same PR as my recent one on `insight`. Goal is to make the `testthat` log easier to read by suppressing package startup messages.