### PR TITLE
tinyverse badge

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -33,6 +33,7 @@ library(parameters)
 [![DOI](https://joss.theoj.org/papers/10.21105/joss.02445/status.svg)](https://doi.org/10.21105/joss.02445)
 [![downloads](http://cranlogs.r-pkg.org/badges/parameters)](https://cran.r-project.org/package=parameters)
 [![total](https://cranlogs.r-pkg.org/badges/grand-total/parameters)](https://cranlogs.r-pkg.org/) 
+[![status](https://tinyverse.netlify.com/badge/parameters)](https://CRAN.R-project.org/package=parameters)
 
 ------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -4,18 +4,19 @@
 [![DOI](https://joss.theoj.org/papers/10.21105/joss.02445/status.svg)](https://doi.org/10.21105/joss.02445)
 [![downloads](http://cranlogs.r-pkg.org/badges/parameters)](https://cran.r-project.org/package=parameters)
 [![total](https://cranlogs.r-pkg.org/badges/grand-total/parameters)](https://cranlogs.r-pkg.org/)
+[![status](https://tinyverse.netlify.com/badge/parameters)](https://CRAN.R-project.org/package=parameters)
 
-------------------------------------------------------------------------
+-----
 
-:warning: For Bayesian models, we changed the default the CI width!
+:warning: For Bayesian models, we changed the default the CI width\!
 Please make an [informed
 decision](https://easystats.github.io/bayestestR/articles/credible_interval.html)
 and set it explicitly (`ci = 0.89`, `ci = 0.95`, or anything else that
 you decide) :warning:
 
-------------------------------------------------------------------------
+-----
 
-***Describe and understand your model’s parameters!***
+***Describe and understand your model’s parameters\!***
 
 **parameters**’ primary goal is to provide utilities for processing the
 parameters of various statistical models (see
@@ -70,21 +71,21 @@ Click on the buttons above to access the package
 [easystats blog](https://easystats.github.io/blog/posts/), and check-out
 these vignettes:
 
--   [Summary of Model
+  - [Summary of Model
     Parameters](https://easystats.github.io/parameters/articles/model_parameters.html)
--   [Standardized Model
+  - [Standardized Model
     Parameters](https://easystats.github.io/parameters/articles/model_parameters_standardized.html)
--   [Robust Estimation of Standard Errors, Confidence Intervals and
+  - [Robust Estimation of Standard Errors, Confidence Intervals and
     p-values](https://easystats.github.io/parameters/articles/model_parameters_robust.html)
--   [Model Parameters and Missing
+  - [Model Parameters and Missing
     Data](https://easystats.github.io/parameters/articles/model_parameters_mice.html)
--   [Feature reduction (PCA, cMDS,
+  - [Feature reduction (PCA, cMDS,
     ICA…)](https://easystats.github.io/parameters/articles/parameters_reduction.html)
--   [Structural models (EFA, CFA,
+  - [Structural models (EFA, CFA,
     SEM…)](https://easystats.github.io/parameters/articles/efa_cfa.html)
--   [Parameters
+  - [Parameters
     selection](https://easystats.github.io/parameters/articles/parameters_selection.html)
--   [A Practical Guide for Panel Data
+  - [A Practical Guide for Panel Data
     Analysis](https://easystats.github.io/parameters/articles/demean.html)
 
 ## Contributing and Support
@@ -100,7 +101,9 @@ email or also file an issue.
 ## Model’s parameters description
 
 <p>
+
 <img src='man/figures/figure1.png' align="center" />
+
 </p>
 
 The
@@ -111,15 +114,15 @@ models in a consistent way. It can be considered as a lightweight
 alternative to [`broom::tidy()`](https://github.com/tidymodels/broom),
 with some notable differences:
 
--   The column names of the returned data frame are *specific* to their
+  - The column names of the returned data frame are *specific* to their
     content. For instance, the column containing the statistic is named
     following the statistic name, i.e., *t*, *z*, etc., instead of a
     generic name such as *statistic* (however, you can get standardized
     (generic) column names using
     [`standardize_names()`](https://easystats.github.io/insight/reference/standardize_names.html)).
--   It is able to compute or extract indices not available by default,
+  - It is able to compute or extract indices not available by default,
     such as *p-values*, *CIs*, etc.
--   It includes *feature engineering* capabilities, including parameters
+  - It includes *feature engineering* capabilities, including parameters
     [bootstrapping](https://easystats.github.io/parameters/reference/bootstrap_parameters.html).
 
 ### Classical Regression Models
@@ -220,7 +223,9 @@ model_parameters(model)
 ## Variable and parameters selection
 
 <p>
+
 <img src='man/figures/figure2.png' align="center" />
+
 </p>
 
 [`select_parameters()`](https://easystats.github.io/parameters/articles/parameters_selection.html)


### PR DESCRIPTION
For me, the main benefit of `parameters` over competitors is that it has virtually no dependencies. This PR adds [a tinyverse badge](https://www.tinyverse.org/) to showcase that great benefit on the README.

I only added one line; the other changes to `README.md` were generated automatically by `rmarkdown::render`