### PR TITLE
Attempt to fix standardize_info for "nlme"

### DIFF
--- a/R/standardize_info.R
+++ b/R/standardize_info.R
@@ -41,7 +41,7 @@ standardize_info.default <- function(model, robust = FALSE, two_sd = FALSE, incl
     insight::find_parameters(model, effects = "fixed", flatten = TRUE, ...)
   }
   types <- parameters_type(model)
-  model_matrix <- as.data.frame(stats::model.matrix(model))
+  model_matrix <- as.data.frame(insight::get_modelmatrix(model))
   data <- insight::get_data(model)
   wgts <- insight::get_weights(model, na_rm = TRUE)
 
@@ -285,8 +285,11 @@ standardize_info.default <- function(model, robust = FALSE, two_sd = FALSE, incl
 #' @keywords internal
 .std_info_response_smart <- function(model, info, data, model_matrix, types, robust = FALSE, w = NULL, ...) {
   if (info$is_linear) {
-    # response <- insight::get_response(model)
-    response <- stats::model.frame(model)[[1]]
+    if (inherits(model, c("gls", "nlme"))) {
+      response <- insight::get_response(model)
+    } else {
+      response <- stats::model.frame(model)[[1]]
+    }
     means <- deviations <- rep(NA_real_, length = length(names(model_matrix)))
     for (i in seq_along(names(model_matrix))) {
       var <- names(model_matrix)[i]
@@ -328,8 +331,11 @@ standardize_info.default <- function(model, robust = FALSE, two_sd = FALSE, incl
 
 #' @keywords internal
 .std_info_response_basic <- function(model, info, params, robust = FALSE, w = NULL, ...) {
-  # response <- insight::get_response(model)
-  response <- stats::model.frame(model)[[1]]
+  if (inherits(model, c("gls", "lme"))) {
+    response <- insight::get_response(model)
+  } else {
+    response <- stats::model.frame(model)[[1]]
+  }
 
   if (info$is_linear) {
     if (robust == FALSE) {


### PR DESCRIPTION
Hello, this PR is related to #706.

```r
library(nlme)
library(parameters)

data("mtcars")
fm1 <- lme(mpg ~ cyl, mtcars, random = ~ 1| gear)
fm2 <- gls(mpg ~ cyl, mtcars)

standardize_info(fm1)
standardize_info(fm2)
```
Replacing `response <- stats::model.frame(model)[[1]]` by `response <- insight::get_response(model)` makes some tests fail in `test-standardize-parameters` and I couldn't find why. This is the reason why there's an if condition for "nlme" and "gls" objects. Not very clean but I couldn't find the origin of the bug introduced.

The example above now runs:
``` r
library(nlme)
library(parameters)

data("mtcars")
fm1 <- lme(mpg ~ cyl, mtcars, random = ~ 1| gear)
fm2 <- gls(mpg ~ cyl, mtcars)

standardize_info(fm1)
#> Warning in mean.default(x, na.rm = TRUE): argument is not numeric or logical:
#> returning NA

#> Warning in mean.default(x, na.rm = TRUE): argument is not numeric or logical:
#> returning NA
#>     Parameter      Type        Link Secondary_Parameter EffectSize_Type
#> 1 (Intercept) intercept        Mean                <NA>            <NA>
#> 2         cyl   numeric Association                <NA>               r
#>   Deviation_Response_Basic Deviation_Response_Smart Deviation_Basic
#> 1                 6.026948                       NA        0.000000
#> 2                 6.026948                       NA        1.785922
#>   Deviation_Smart
#> 1        0.000000
#> 2        1.785922
standardize_info(fm2)
#>     Parameter      Type        Link Secondary_Parameter EffectSize_Type
#> 1 (Intercept) intercept        Mean                <NA>            <NA>
#> 2         cyl   numeric Association                <NA>               r
#>   Deviation_Response_Basic Deviation_Response_Smart Deviation_Basic
#> 1                 6.026948                 6.026948        0.000000
#> 2                 6.026948                 6.026948        1.785922
#>   Deviation_Smart
#> 1        0.000000
#> 2        1.785922
```

<sup>Created on 2022-05-06 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Note however that I'm **not sure whether the results are correct** (I just wanted the code to run). I hope this helps.

Close #706.