### PR TITLE
Support `car::linearHypothesis`

### DIFF
--- a/R/extract_parameters_anova.R
+++ b/R/extract_parameters_anova.R
@@ -69,7 +69,7 @@
 
   # Reorder
   row.names(parameters) <- NULL
-  order <- c("Response", "Group", "Parameter", "Hypothesis", "Coefficient", "SE", "Pillai", "AIC", "BIC", "Log_Likelihood", "Chi2", "Chi2_df", "RSS", "Sum_Squares", "Sum_Squares_Partial", "Sum_Squares_Error", "df", "Deviance", "Statistic", "df_num", "df_error", "Deviance_error", "Mean_Square", "F", "Rao", "p")
+  order <- c("Response", "Group", "Parameter", "Coefficient", "SE", "Pillai", "AIC", "BIC", "Log_Likelihood", "Chi2", "Chi2_df", "RSS", "Sum_Squares", "Sum_Squares_Partial", "Sum_Squares_Error", "df", "Deviance", "Statistic", "df_num", "df_error", "Deviance_error", "Mean_Square", "F", "Rao", "p")
   parameters <- parameters[order[order %in% names(parameters)]]
 
   insight::text_remove_backticks(parameters, verbose = FALSE)

--- a/R/extract_parameters_anova.R
+++ b/R/extract_parameters_anova.R
@@ -69,7 +69,7 @@
 
   # Reorder
   row.names(parameters) <- NULL
-  order <- c("Response", "Group", "Parameter", "Pillai", "AIC", "BIC", "Log_Likelihood", "Chi2", "Chi2_df", "RSS", "Sum_Squares", "Sum_Squares_Partial", "Sum_Squares_Error", "df", "Deviance", "Statistic", "df_num", "df_error", "Deviance_error", "Mean_Square", "F", "Rao", "p")
+  order <- c("Response", "Group", "Parameter", "Hypothesis", "Coefficient", "SE", "Pillai", "AIC", "BIC", "Log_Likelihood", "Chi2", "Chi2_df", "RSS", "Sum_Squares", "Sum_Squares_Partial", "Sum_Squares_Error", "df", "Deviance", "Statistic", "df_num", "df_error", "Deviance_error", "Mean_Square", "F", "Rao", "p")
   parameters <- parameters[order[order %in% names(parameters)]]
 
   insight::text_remove_backticks(parameters, verbose = FALSE)
@@ -179,6 +179,27 @@
   if (length(df_num) == 0 && length(sumsq) != 0 && "Mean_Square" %in% colnames(parameters) && !("Df" %in% colnames(parameters))) {
     parameters$Df <- round(parameters[[sumsq]] / parameters$Mean_Square)
   }
+
+  # Special catch for car::linearHypothesis
+  m_attr = attributes(model)
+  if (!is.null(m_attr$value) && isTRUE(grepl("^Linear hypothesis", m_attr$heading[[1]]))) {
+    # Drop unrestricted model (not interesting in linear hypothesis tests)
+    # Use formula to subset if available (e.g. with car::linearHypothesis)
+    if (length(grep("Model", m_attr$heading)) != 0) {
+      idx <- sub(".*: ", "", strsplit(m_attr$heading[grep("Model", m_attr$heading)], "\n")[[1]])
+      idx <- idx != "restricted model"
+      parameters <- parameters[idx, , drop = FALSE]
+    }
+    hypothesis = m_attr$heading[grep("=", m_attr$heading)]
+    parameters_xtra = data.frame(
+      Parameter = hypothesis,
+      Coefficient = m_attr$value, 
+      SE = sqrt(as.numeric(diag(m_attr$vcov))))
+    row.names(parameters_xtra) = row.names(parameters) <- NULL
+    parameters = cbind(parameters_xtra, parameters)
+    parameters$Parameter = gsub("  ", " ", parameters$Parameter) ## Annoying extra space sometimes
+  }
+
   parameters
 }
 

--- a/R/extract_parameters_anova.R
+++ b/R/extract_parameters_anova.R
@@ -181,7 +181,7 @@
   }
 
   # Special catch for car::linearHypothesis
-  m_attr = attributes(model)
+  m_attr <- attributes(model)
   if (!is.null(m_attr$value) && isTRUE(grepl("^Linear hypothesis", m_attr$heading[[1]]))) {
     # Drop unrestricted model (not interesting in linear hypothesis tests)
     # Use formula to subset if available (e.g. with car::linearHypothesis)
@@ -190,14 +190,14 @@
       idx <- idx != "restricted model"
       parameters <- parameters[idx, , drop = FALSE]
     }
-    hypothesis = m_attr$heading[grep("=", m_attr$heading)]
-    parameters_xtra = data.frame(
+    hypothesis <- m_attr$heading[grep("=", m_attr$heading)]
+    parameters_xtra <- data.frame(
       Parameter = hypothesis,
       Coefficient = m_attr$value, 
       SE = sqrt(as.numeric(diag(m_attr$vcov))))
-    row.names(parameters_xtra) = row.names(parameters) <- NULL
-    parameters = cbind(parameters_xtra, parameters)
-    parameters$Parameter = gsub("  ", " ", parameters$Parameter) ## Annoying extra space sometimes
+    row.names(parameters_xtra) <- row.names(parameters) <- NULL
+    parameters <- cbind(parameters_xtra, parameters)
+    parameters$Parameter <- gsub("  ", " ", parameters$Parameter) ## Annoying extra space sometimes
   }
 
   parameters

--- a/R/standardize_parameters.R
+++ b/R/standardize_parameters.R
@@ -70,7 +70,7 @@
 #' on a fitted random-intercept-model, where `sqrt(random-intercept-variance)`
 #' is used for level 2 predictors, and `sqrt(residual-variance)` is used for
 #' level 1 predictors (Hoffman 2015, page 342). A warning is given when a
-#' within-group varialbe is found to have access between-group variance.
+#' within-group variable is found to have access between-group variance.
 #'
 #' # Transformed Variables
 #' When the model's formula contains transformations (e.g. `y ~ exp(X)`) `method

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -61,7 +61,7 @@ df
 DirichletReg
 DoF
 DoFs
-DOI
+doi
 DRR
 Dupont
 easystats
@@ -82,7 +82,7 @@ et
 exponentiate
 exponentiating
 FactoMineR
-fastICA
+FastICA
 Fidell
 gam
 gamlss

--- a/man/standardize_parameters.Rd
+++ b/man/standardize_parameters.Rd
@@ -124,7 +124,7 @@ are standardized based on their SD at level of prediction (see also
 on a fitted random-intercept-model, where \code{sqrt(random-intercept-variance)}
 is used for level 2 predictors, and \code{sqrt(residual-variance)} is used for
 level 1 predictors (Hoffman 2015, page 342). A warning is given when a
-within-group varialbe is found to have access between-group variance.
+within-group variable is found to have access between-group variance.
 }
 }
 

--- a/tests/testthat/test-model_parameters.anova.R
+++ b/tests/testthat/test-model_parameters.anova.R
@@ -41,6 +41,27 @@ if (.runThisTest && requiet("insight") && requiet("testthat") && requiet("parame
       expect_equal(mp[["F"]], c(53.40138, 60.42944, 13.96887, NA), tolerance = 1e-3)
     })
 
+    test_that("linear hypothesis tests", {
+      requiet("car")
+      mod.davis <- lm(weight ~ repwt, data=Davis)
+      
+      ## the following are equivalent:
+      p1 <- parameters(linearHypothesis(mod.davis, diag(2), c(0,1)))
+      p2 <- parameters(linearHypothesis(mod.davis, c("(Intercept) = 0", "repwt = 1")))
+      p3 <- parameters(linearHypothesis(mod.davis, c("(Intercept)", "repwt"), c(0,1)))
+      p4 <- parameters(linearHypothesis(mod.davis, c("(Intercept)", "repwt = 1")))
+      expect_equal(p1, p2, ignore_attr = TRUE)
+      expect_equal(p1, p3, ignore_attr = TRUE)
+      expect_equal(p1, p4, ignore_attr = TRUE)
+      expect_equal(nrow(p1), 2)
+      expect_equal(p1$Parameter, c("(Intercept) = 0", "repwt = 1"))
+ 
+      mod.duncan <- lm(prestige ~ income + education, data=Duncan)
+      p <- parameters(linearHypothesis(mod.duncan, "1*income - 1*education + 1 = 1"))
+      expect_equal(nrow(p), 1)
+      expect_equal(p$Parameter, "income - education = 0")
+    })
+
     test_that("print-model_parameters", {
       out <- utils::capture.output(print(mp))
       expect_equal(


### PR DESCRIPTION
This function returns an object of class `.anova` with special attributes. So I added a conditional block to process this object in `.extract_anova_anova`. It checks for a special header that should appear in no other anova models, son in principle it shouldn't affect anything else.

The anova `standard_error()` method only calls `model_parameters()`, so it works. I noticed there isn't an `ci.anova()` method, but I can't implement one now.