### PR TITLE
Fix failing test for VGAM

### DIFF
--- a/tests/testthat/test-model_parameters.vgam.R
+++ b/tests/testthat/test-model_parameters.vgam.R
@@ -22,7 +22,7 @@ if (.runThisTest && requiet("testthat") && requiet("VGAM") && requiet("parameter
     params <- suppressWarnings(model_parameters(m1))
     expect_equal(params$Coefficient, as.vector(m1@coefficients[params$Parameter]), tolerance = 1e-3)
     expect_equal(params$Parameter, c("(Intercept):1", "(Intercept):2", "exposure.time", "s(let)"))
-    expect_equal(params$df, c(NA, NA, NA, 2.77342), tolerance = 1e-3)
+    expect_equal(params$df, c(NA, NA, NA, 2.6501), tolerance = 1e-3)
     expect_equal(as.vector(na.omit(params$df)), as.vector(m1@nl.df), tolerance = 1e-3)
   })
 


### PR DESCRIPTION
Some values (df, Npar, etc.) changed between VGAM 1.1-6 and 1.1-7 (released last week):
* `remotes::install_version("VGAM", "1.1-6")`
``` r
library(VGAM)
#> Loading required package: stats4
#> Loading required package: splines

data("pneumo")
data("hunua")

set.seed(123)
pneumo <- transform(pneumo, let = log(exposure.time))

m1 <- suppressWarnings(vgam(
  cbind(normal, mild, severe) ~ s(let) + exposure.time,
  cumulative(parallel = TRUE),
  data = pneumo,
  trace = FALSE
))
summary(m1)
#> 
#> Call:
#> vgam(formula = cbind(normal, mild, severe) ~ s(let) + exposure.time, 
#>     family = cumulative(parallel = TRUE), data = pneumo, trace = FALSE)
#> 
#> Names of additive predictors: logitlink(P[Y<=1]), logitlink(P[Y<=2])
#> 
#> Dispersion Parameter for cumulative family:   1
#> 
#> Residual deviance:  2.72272 on 9.227 degrees of freedom
#> 
#> Log-likelihood: -23.93821 on 9.227 degrees of freedom
#> 
#> Number of Fisher scoring iterations:  30 
#> 
#> DF for Terms and Approximate Chi-squares for Nonparametric Effects
#> 
#>               Df Npar Df Npar Chisq  P(Chi)
#> (Intercept):1  1                           
#> (Intercept):2  1                           
#> s(let)         1     2.8    2.36122 0.45819
#> exposure.time  1
```
<sup>Created on 2022-07-11 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

* `install.packages("VGAM")`
``` r
library(VGAM)
#> Warning: package 'VGAM' was built under R version 4.2.1
#> Loading required package: stats4
#> Loading required package: splines

data("pneumo")
data("hunua")

set.seed(123)
pneumo <- transform(pneumo, let = log(exposure.time))

m1 <- suppressWarnings(vgam(
  cbind(normal, mild, severe) ~ s(let) + exposure.time,
  cumulative(parallel = TRUE),
  data = pneumo,
  trace = FALSE
))
summary(m1)
#> 
#> Call:
#> vgam(formula = cbind(normal, mild, severe) ~ s(let) + exposure.time, 
#>     family = cumulative(parallel = TRUE), data = pneumo, trace = FALSE)
#> 
#> Names of additive predictors: logitlink(P[Y<=1]), logitlink(P[Y<=2])
#> 
#> Dispersion Parameter for cumulative family:   1
#> 
#> Residual deviance:  2.36549 on 9.35 degrees of freedom
#> 
#> Log-likelihood: -23.75959 on 9.35 degrees of freedom
#> 
#> Number of Fisher scoring iterations:  30 
#> 
#> DF for Terms and Approximate Chi-squares for Nonparametric Effects
#> 
#>               Df Npar Df Npar Chisq  P(Chi)
#> (Intercept):1  1                           
#> (Intercept):2  1                           
#> s(let)         1     2.7    1.77341 0.55276
#> exposure.time  1
```

<sup>Created on 2022-07-11 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
