### PR TITLE
change `data_set` attribute name for `dataset` (in PCA/EFA)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## Breaking
 
+* The attribute name in PCA / EFA has been changed from `data_set` to `dataset`.
+
 * The minimum needed R version has been bumped to `3.6`.
 
 * Removed deprecated argument `parameters` from `model_parameters()`.
@@ -37,7 +39,7 @@
 
 ## New functions
 
-* New function `dominance_analysis()`, to compute dominance analysis 
+* New function `dominance_analysis()`, to compute dominance analysis
   statistics and designations.
 
 ## Changes to functions
@@ -79,20 +81,20 @@
 
 * `model_parameters()` for mixed models gains a `ci_random` argument, to toggle
   whether confidence intervals for random effects parameters should also be
-  computed. Set to `FALSE` if calculation of confidence intervals for random 
+  computed. Set to `FALSE` if calculation of confidence intervals for random
   effects parameters takes too long.
 
 * `ci()` for *glmmTMB* models with `method = "profile"` is now more robust.
 
 ## Bug fixes
 
-* Fixed issue with *glmmTMB* models when calculating confidence 
+* Fixed issue with *glmmTMB* models when calculating confidence
   intervals for random effects failed due to singular fits.
-  
+
 * `display()` now correctly includes custom text and additional information
   in the footer (#722).
 
-* Fixed issue with argument `column_names` in `compare_parameters()` when 
+* Fixed issue with argument `column_names` in `compare_parameters()` when
   strings contained characters that needed to be escaped for regular expressions.
 
 * Fixed issues with unknown arguments in `model_parameters()` for *lavaan* models
@@ -119,10 +121,10 @@
 
 * `model_parameters()` for mixed models from package *lme4* now also reports
   confidence intervals for random effect variances by default. Formerly, CIs
-  were only included when `ci_method` was `"profile"` or `"boot"`. The 
+  were only included when `ci_method` was `"profile"` or `"boot"`. The
   *merDeriv* package is required for this feature.
 
-* `model_parameters()` for `htest` objects now also supports models from 
+* `model_parameters()` for `htest` objects now also supports models from
   `var.test()`.
 
 * Improved support for `anova.rms` models in `model_parameters()`.
@@ -131,12 +133,12 @@
   and `deltaMethods` objects from package *car*.
 
 * `model_parameters()` now checks arguments and informs the user if specific
-  given arguments are not supported for that model class (e.g., `"vcov"` is 
+  given arguments are not supported for that model class (e.g., `"vcov"` is
   currently not supported for models of class *glmmTMB*).
 
 ## Bug fixes
 
-* The `vcov` argument, used for computing robust standard errors, did not 
+* The `vcov` argument, used for computing robust standard errors, did not
   calculate the correct p-values and confidence intervals for models of class
   `lme`.
 
@@ -154,7 +156,7 @@
 * Added options to set defaults for different arguments. Currently supported:
   - `options("parameters_summary" = TRUE/FALSE)`, which sets the default value
     for the `summary` argument in `model_parameters()` for non-mixed models.
-  - `options("parameters_mixed_summary" = TRUE/FALSE)`, which sets the default 
+  - `options("parameters_mixed_summary" = TRUE/FALSE)`, which sets the default
     value for the `summary` argument in `model_parameters()` for mixed models.
 
 * Minor improvements for `print()` methods.
@@ -192,8 +194,8 @@
 
 * `model_parameters()` for mixed models gains an `include_sigma` argument. If
   `TRUE`, adds the residual variance, computed from the random effects variances,
-  as an attribute to the returned data frame. Including sigma was the default 
-  behaviour, but now defaults to `FALSE` and is only included when 
+  as an attribute to the returned data frame. Including sigma was the default
+  behaviour, but now defaults to `FALSE` and is only included when
   `include_sigma = TRUE`, because the calculation was very time consuming.
 
 * `model_parameters()` for `merMod` models now also computes CIs for the random
@@ -213,14 +215,14 @@
 * `model_prameters()` for `MixMod` objects (package *GLMMadaptive*) gains a
   `robust` argument, to compute robust standard errors.
 
-## Bug fixes 
+## Bug fixes
 
 * Fixed bug with `ci()` for class `merMod` when `method="boot"`.
 
-* Fixed issue with correct association of components for ordinal models of 
+* Fixed issue with correct association of components for ordinal models of
   classes `clm` and `clm2`.
 
-* Fixed issues in `random_parameters()` and  `model_parameters()` for mixed 
+* Fixed issues in `random_parameters()` and  `model_parameters()` for mixed
   models without random intercept.
 
 * Confidence intervals for random parameters in `model_parameters()` failed for

--- a/R/factor_analysis.R
+++ b/R/factor_analysis.R
@@ -81,6 +81,6 @@ factor_analysis.data.frame <- function(x,
     )
   }
 
-  attr(out, "data_set") <- x
+  attr(out, "dataset") <- x
   out
 }

--- a/R/principal_components.R
+++ b/R/principal_components.R
@@ -252,7 +252,7 @@ principal_components.data.frame <- function(x,
   # original data
   original_data <- x
 
-  # remove missings
+  # remove missing
   x <- stats::na.omit(x)
 
   # PCA
@@ -360,7 +360,7 @@ principal_components.data.frame <- function(x,
     .closest_component(loadings, loadings_columns = loading_cols, variable_names = colnames(x))
   attr(loadings, "data") <- data_name
 
-  attr(loadings, "data_set") <- original_data
+  attr(loadings, "dataset") <- original_data
 
   # add class-attribute for printing
   class(loadings) <- unique(c("parameters_pca", "see_parameters_pca", class(loadings)))

--- a/R/principal_components.R
+++ b/R/principal_components.R
@@ -215,7 +215,7 @@ principal_components <- function(x,
 #' @rdname principal_components
 #' @export
 rotated_data <- function(pca_results) {
-  original_data <- attributes(pca_results)$data_set
+  original_data <- attributes(pca_results)$dataset
   rotated_matrix <- insight::get_predicted(attributes(pca_results)$model)
   out <- NULL
 
@@ -420,7 +420,7 @@ principal_components.data.frame <- function(x,
   attr(pca, "MSA") <- msa$MSAi
   out <- model_parameters(pca, sort = sort, threshold = threshold)
 
-  attr(out, "data_set") <- original_data
+  attr(out, "dataset") <- original_data
   attr(out, "complete_cases") <- stats::complete.cases(original_data)
   out
 }

--- a/R/utils_pca_efa.R
+++ b/R/utils_pca_efa.R
@@ -39,11 +39,11 @@
 #' @export
 get_scores <- function(x, n_items = NULL) {
   subscales <- closest_component(x)
-  data_set <- attributes(x)$data_set
+  dataset <- attributes(x)$dataset
 
   out <- lapply(sort(unique(subscales)), function(.subscale) {
     columns <- names(subscales)[subscales == .subscale]
-    items <- data_set[columns]
+    items <- dataset[columns]
 
     if (is.null(n_items)) {
       .n_items <- round(ncol(items) / 2)
@@ -149,8 +149,8 @@ predict.parameters_efa <- function(object,
         out <- .merge_na(object, out)
       }
     } else {
-      if ("data_set" %in% names(attri)) {
-        out <- as.data.frame(stats::predict(attri$model, data = attri$data_set))
+      if ("dataset" %in% names(attri)) {
+        out <- as.data.frame(stats::predict(attri$model, data = attri$dataset))
       } else {
         stop(insight::format_message(
           "Could not retrieve data nor model. Please report an issue on {.url https://github.com/easystats/parameters/issues}."


### PR DESCRIPTION
It's just nicer to have it in one word, but is it worth it?