### PR TITLE
Issue #779: marginal effects labels

### DIFF
--- a/R/methods_marginaleffects.R
+++ b/R/methods_marginaleffects.R
@@ -14,6 +14,10 @@ model_parameters.marginaleffects <- function(model,
     style = "easystats"
   )
 
+  # contrast_ columns provide indispensable information about the comparisons 
+  colnames(out)[colnames(out) == "contrast"] <- "Comparison"
+  colnames(out) <- gsub("^contrast_", "Comparison: ", colnames(out))
+
   out <- tryCatch(
     .add_model_parameters_attributes(out, model, ci, ...),
     error = function(e) out

--- a/tests/testthat/test-marginaleffects.R
+++ b/tests/testthat/test-marginaleffects.R
@@ -46,3 +46,17 @@ test_that("deltamethod()", {
   m <- deltamethod(x, "hp = wt")
   expect_equal(nrow(parameters(m)), 1)
 })
+
+
+
+test_that("multiple contrasts: Issue #779", {
+  mod <- lm(mpg ~ as.factor(gear) * as.factor(cyl), data = mtcars)
+  cmp <- suppressWarnings(comparisons(
+    mod,
+    variables = c("gear", "cyl"),
+    newdata = insight::get_datagrid(mod, at = c("gear", "cyl")),
+    interaction = TRUE))
+  cmp <- parameters(cmp)
+  expect_true("Comparison: gear" %in% colnames(cmp))
+  expect_true("Comparison: cyl" %in% colnames(cmp))
+})


### PR DESCRIPTION
Improves labels for `model_parameters` with `marginaleffects` objects.

Initially reported by @strengejacke 