### PR TITLE
replace interaction sep with "x" à la modelsummary

### DIFF
--- a/R/1_model_parameters.R
+++ b/R/1_model_parameters.R
@@ -520,7 +520,7 @@ model_parameters.default <- function(model,
     )
   }
 
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }
 
@@ -689,6 +689,6 @@ model_parameters.glm <- function(model,
   args <- c(args, dots)
   out <- do.call(".model_parameters_generic", args)
 
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }

--- a/R/1_model_parameters.R
+++ b/R/1_model_parameters.R
@@ -309,7 +309,9 @@ model_parameters <- function(model, ...) {
 # getOption("parameters_mixed_summary"): show model summary for mixed models
 # getOption("parameters_cimethod"): show message about CI approximation
 # getOption("parameters_exponentiate"): show warning about exp for log/logit links
-
+# getOption("parameters_labels"): use value/variable labels instead pretty names
+# getOption("parameters_interaction"): separator char for interactions
+# getOption("parameters_select"): default for the `select` argument
 
 
 #' @rdname model_parameters

--- a/R/5_simulate_model.R
+++ b/R/5_simulate_model.R
@@ -68,7 +68,7 @@ simulate_model.default <- function(model, iterations = 1000, ...) {
   out <- .simulate_model(model, iterations, component = "conditional", effects = "fixed", ...)
 
   class(out) <- c("parameters_simulate_model", class(out))
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }
 

--- a/R/equivalence_test.R
+++ b/R/equivalence_test.R
@@ -169,7 +169,7 @@ equivalence_test.lm <- function(x,
   if (is.null(attr(out, "pretty_names", exact = TRUE))) {
     attr(out, "pretty_names") <- format_parameters(x)
   }
-  attr(out, "object_name") <- insight::safe_deparse_substitute(x)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(x))
   attr(out, "rule") <- rule
   class(out) <- c("equivalence_test_lm", "see_equivalence_test_lm", class(out))
   out
@@ -247,7 +247,7 @@ equivalence_test.merMod <- function(x,
   if (is.null(attr(out, "pretty_names", exact = TRUE))) {
     attr(out, "pretty_names") <- format_parameters(x)
   }
-  attr(out, "object_name") <- insight::safe_deparse_substitute(x)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(x))
   attr(out, "rule") <- rule
   class(out) <- c("equivalence_test_lm", "see_equivalence_test_lm", class(out))
   out

--- a/R/format_parameters.R
+++ b/R/format_parameters.R
@@ -272,7 +272,7 @@ format_parameters.parameters_model <- function(model, ...) {
   # sep <- ifelse(is_nested | is_simple, " : ", " * ")
   # sep <- ifelse(is_nested, " / ", " * ")
   # sep <- ifelse(is_simple, " : ", ifelse(is_nested, " / ", " * "))
-  sep <- " * "
+  sep <- " x "
 
   if (length(components) > 2) {
     if (type == "interaction") {

--- a/R/format_parameters.R
+++ b/R/format_parameters.R
@@ -193,7 +193,8 @@ format_parameters.parameters_model <- function(model, ...) {
         components,
         type = types[i, "Type"],
         is_nested = is_nested,
-        is_simple = is_simple
+        is_simple = is_simple,
+        ...
       )
     }
   }
@@ -268,17 +269,29 @@ format_parameters.parameters_model <- function(model, ...) {
 
 
 #' @keywords internal
-.format_interaction <- function(components, type, is_nested = FALSE, is_simple = FALSE) {
+.format_interaction <- function(components,
+                                type,
+                                is_nested = FALSE,
+                                is_simple = FALSE,
+                                interaction_sep = "*",
+                                ...) {
   # sep <- ifelse(is_nested | is_simple, " : ", " * ")
   # sep <- ifelse(is_nested, " / ", " * ")
   # sep <- ifelse(is_simple, " : ", ifelse(is_nested, " / ", " * "))
-  sep <- " x "
+  if (is.null(interaction_sep)) {
+    sep <- "*"
+  } else {
+    sep <- interaction_sep
+  }
+
+  # either use argument, or override with options
+  sep <- paste0(" ", getOption("parameters_interaction", insight::trim_ws(sep)), " ")
 
   if (length(components) > 2) {
     if (type == "interaction") {
       components <- paste0(
         "(",
-        paste0(utils::head(components, -1), collapse = " * "),
+        paste0(utils::head(components, -1), collapse = sep),
         ")",
         sep,
         utils::tail(components, 1)

--- a/R/methods_BayesFactor.R
+++ b/R/methods_BayesFactor.R
@@ -229,7 +229,7 @@ model_parameters.BFBayesFactor <- function(model,
 
 
   attr(out, "title") <- unique(out$Method)
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   attr(out, "pretty_names") <- pretty_names
   attr(out, "ci_test") <- ci
 

--- a/R/methods_DirichletReg.R
+++ b/R/methods_DirichletReg.R
@@ -32,7 +32,7 @@ model_parameters.DirichletRegModel <- function(model,
   ))
 
   out$Response[is.na(out$Response)] <- ""
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }
 

--- a/R/methods_MCMCglmm.R
+++ b/R/methods_MCMCglmm.R
@@ -60,7 +60,7 @@ model_parameters.MCMCglmm <- function(model,
 
   attr(params, "pretty_names") <- format_parameters(model)
   attr(params, "ci") <- ci
-  attr(params, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(params, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   class(params) <- c("parameters_model", "see_parameters_model", class(params))
 
   params

--- a/R/methods_aod.R
+++ b/R/methods_aod.R
@@ -45,7 +45,7 @@ model_parameters.glimML <- function(model,
     ...
   )
 
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }
 

--- a/R/methods_aov.R
+++ b/R/methods_aov.R
@@ -134,7 +134,7 @@ model_parameters.aov <- function(model,
 
   # save model object, for later checks
   original_model <- model
-  object_name <- insight::safe_deparse_substitute(model)
+  object_name <- insight::safe_deparse_symbol(substitute(model))
 
   if (inherits(model, "aov") && !is.null(type) && type > 1) {
     if (!requireNamespace("car", quietly = TRUE)) {
@@ -315,7 +315,7 @@ model_parameters.afex_aov <- function(model,
   }
 
   attr(out, "title") <- unique(out$Method)
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   class(out) <- unique(c("parameters_model", "see_parameters_model", class(out)))
 
   out

--- a/R/methods_averaging.R
+++ b/R/methods_averaging.R
@@ -53,7 +53,7 @@ model_parameters.averaging <- function(model,
     ...
   )
 
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }
 

--- a/R/methods_bamlss.R
+++ b/R/methods_bamlss.R
@@ -46,7 +46,7 @@ model_parameters.bamlss <- function(model,
   params <- .add_model_parameters_attributes(params, model, ci, exponentiate, ci_method = ci_method, verbose = verbose, ...)
 
   attr(params, "parameter_info") <- insight::clean_parameters(model)
-  attr(params, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(params, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   class(params) <- unique(c("parameters_stan", "see_parameters_model", "parameters_model", class(params)))
 
   params

--- a/R/methods_bayesQR.R
+++ b/R/methods_bayesQR.R
@@ -35,7 +35,7 @@ model_parameters.bayesQR <- function(model,
   )
 
   attr(params, "ci") <- ci
-  attr(params, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(params, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   class(params) <- c("parameters_model", "see_parameters_model", class(params))
 
   params

--- a/R/methods_betareg.R
+++ b/R/methods_betareg.R
@@ -45,7 +45,7 @@ model_parameters.betareg <- function(model,
   args <- c(args, dot_args)
 
   out <- do.call(".model_parameters_generic", args)
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }
 
@@ -148,6 +148,6 @@ simulate_model.betareg <- function(model,
   out <- .simulate_model(model, iterations, component = component, ...)
 
   class(out) <- c("parameters_simulate_model", class(out))
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }

--- a/R/methods_bfsl.R
+++ b/R/methods_bfsl.R
@@ -15,7 +15,7 @@ model_parameters.bfsl <- function(model,
     ...
   )
 
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }
 

--- a/R/methods_brglm2.R
+++ b/R/methods_brglm2.R
@@ -56,7 +56,7 @@ model_parameters.bracl <- function(model,
   args <- c(args, dot_args)
 
   out <- do.call(".model_parameters_generic", args)
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }
 
@@ -242,7 +242,7 @@ simulate_parameters.multinom <- function(model,
   }
 
   class(out) <- c("parameters_simulate", "see_parameters_simulate", class(out))
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   attr(out, "iterations") <- iterations
   attr(out, "ci") <- ci
   attr(out, "ci_method") <- ci_method

--- a/R/methods_brms.R
+++ b/R/methods_brms.R
@@ -86,7 +86,7 @@ model_parameters.brmsfit <- function(model,
     )
 
     attr(params, "parameter_info") <- insight::clean_parameters(model)
-    attr(params, "object_name") <- insight::safe_deparse_substitute(model)
+    attr(params, "object_name") <- insight::safe_deparse_symbol(substitute(model))
     class(params) <- unique(c("parameters_stan", "see_parameters_model", "parameters_model", class(params)))
   }
 

--- a/R/methods_car.R
+++ b/R/methods_car.R
@@ -55,7 +55,7 @@ model_parameters.deltaMethod <- function(model, p_adjust = NULL, verbose = TRUE,
   params <- do.call(".add_model_parameters_attributes", args)
 
   class(params) <- c("parameters_model", "see_parameters_model", class(params))
-  attr(params, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(params, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   attr(params, "no_caption") <- TRUE
   params
 }

--- a/R/methods_cgam.R
+++ b/R/methods_cgam.R
@@ -119,7 +119,7 @@ model_parameters.cgam <- function(model,
     params$CI[is.na(params$CI_low)] <- NA
   }
 
-  attr(params, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(params, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   class(params) <- c("parameters_model", "see_parameters_model", class(params))
 
   params

--- a/R/methods_cplm.R
+++ b/R/methods_cplm.R
@@ -79,7 +79,7 @@ model_parameters.zcpglm <- function(model,
     verbose = verbose,
     ...
   )
-  attr(params, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(params, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   class(params) <- c("parameters_model", "see_parameters_model", class(params))
 
   params
@@ -265,7 +265,7 @@ model_parameters.cpglmm <- function(model,
     ...
   )
 
-  attr(params, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(params, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   class(params) <- c("parameters_model", "see_parameters_model", "data.frame")
 
   params

--- a/R/methods_emmeans.R
+++ b/R/methods_emmeans.R
@@ -123,7 +123,7 @@ model_parameters.emmGrid <- function(model,
   }
 
   params <- suppressWarnings(.add_model_parameters_attributes(params, model, ci, exponentiate = FALSE, p_adjust = p_adjust, verbose = verbose, ...))
-  attr(params, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(params, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   attr(params, "parameter_names") <- parameter_names
 
   class(params) <- c("parameters_model", "see_parameters_model", class(params))
@@ -163,7 +163,7 @@ model_parameters.emm_list <- function(model,
 
   params <- .add_model_parameters_attributes(params, model, ci, exponentiate, p_adjust = p_adjust, verbose = verbose, ...)
 
-  attr(params, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(params, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   class(params) <- c("parameters_model", "see_parameters_model", class(params))
 
   params

--- a/R/methods_fitdistr.R
+++ b/R/methods_fitdistr.R
@@ -15,7 +15,7 @@ model_parameters.fitdistr <- function(model,
   out <- .exponentiate_parameters(out, model, exponentiate)
 
   class(out) <- c("parameters_model", "see_parameters_model", class(out))
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }
 

--- a/R/methods_gam.R
+++ b/R/methods_gam.R
@@ -61,7 +61,7 @@ simulate_model.gam <- function(model, iterations = 1000, ...) {
   out <- as.data.frame(.mvrnorm(n = iterations, mu = beta, Sigma = varcov))
 
   class(out) <- c("parameters_simulate_model", class(out))
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }
 

--- a/R/methods_ggeffects.R
+++ b/R/methods_ggeffects.R
@@ -60,7 +60,7 @@ model_parameters.ggeffects <- function(model, keep = NULL, drop = NULL, verbose 
   attr(model, "footer_text") <- .generate_ggeffects_footer(constant_values)
   attr(model, "title") <- c(title, "blue")
 
-  attr(model, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(model, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   class(model) <- c("parameters_model", "data.frame")
   model
 }

--- a/R/methods_gjrm.R
+++ b/R/methods_gjrm.R
@@ -22,7 +22,7 @@ model_parameters.SemiParBIV <- function(model,
     ...
   )
 
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }
 

--- a/R/methods_glmm.R
+++ b/R/methods_glmm.R
@@ -22,7 +22,7 @@ model_parameters.glmm <- function(model,
     ...
   )
 
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }
 

--- a/R/methods_glmmTMB.R
+++ b/R/methods_glmmTMB.R
@@ -249,7 +249,7 @@ model_parameters.glmmTMB <- function(model,
     ...
   )
 
-  attr(params, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(params, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   class(params) <- c("parameters_model", "see_parameters_model", class(params))
 
   params
@@ -455,7 +455,7 @@ simulate_model.glmmTMB <- function(model,
   }
 
   class(d) <- c("parameters_simulate_model", class(d))
-  attr(d, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(d, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   d
 }
 
@@ -495,7 +495,7 @@ simulate_parameters.glmmTMB <- function(model,
   }
 
   class(out) <- c("parameters_simulate", "see_parameters_simulate", class(out))
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   attr(out, "iterations") <- iterations
   attr(out, "ci") <- ci
   attr(out, "ci_method") <- ci_method

--- a/R/methods_glmx.R
+++ b/R/methods_glmx.R
@@ -30,7 +30,7 @@ model_parameters.glmx <- function(model,
     ...
   )
 
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }
 
@@ -68,6 +68,6 @@ simulate_model.glmx <- function(model, iterations = 1000, component = c("all", "
   out <- .simulate_model(model, iterations, component = component, ...)
 
   class(out) <- c("parameters_simulate_model", class(out))
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }

--- a/R/methods_ivfixed.R
+++ b/R/methods_ivfixed.R
@@ -49,6 +49,6 @@ model_parameters.ivFixed <- function(model,
     verbose = verbose,
     ...
   )
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }

--- a/R/methods_lavaan.R
+++ b/R/methods_lavaan.R
@@ -88,7 +88,7 @@ model_parameters.blavaan <- function(model,
     ...
   )
 
-  attr(params, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(params, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   class(params) <- c("parameters_sem", "see_parameters_sem", class(params))
 
   params

--- a/R/methods_lme4.R
+++ b/R/methods_lme4.R
@@ -281,7 +281,7 @@ model_parameters.merMod <- function(model,
   )
 
 
-  attr(params, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(params, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   class(params) <- c("parameters_model", "see_parameters_model", class(params))
 
   params

--- a/R/methods_lmodel2.R
+++ b/R/methods_lmodel2.R
@@ -29,7 +29,7 @@ model_parameters.lmodel2 <- function(model,
     ...
   )
 
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }
 

--- a/R/methods_lqmm.R
+++ b/R/methods_lqmm.R
@@ -35,7 +35,7 @@ model_parameters.lqmm <- function(model,
     ...
   )
 
-  attr(parameters, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(parameters, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   class(parameters) <- c("parameters_model", "see_parameters_model", class(parameters))
 
   parameters

--- a/R/methods_marginaleffects.R
+++ b/R/methods_marginaleffects.R
@@ -23,7 +23,7 @@ model_parameters.marginaleffects <- function(model,
     error = function(e) out
   )
 
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
 
   if (inherits(model, "marginalmeans")) {
     attr(out, "coefficient_name") <- "Marginal Means"
@@ -79,7 +79,7 @@ model_parameters.predictions <- function(model,
     error = function(e) out
   )
 
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   attr(out, "coefficient_name") <- "Predicted"
   attr(out, "no_caption") <- TRUE
 

--- a/R/methods_margins.R
+++ b/R/methods_margins.R
@@ -46,7 +46,7 @@ model_parameters.margins <- function(model, ci = 0.95, exponentiate = FALSE, p_a
     ...
   )
 
-  attr(params, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(params, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   class(params) <- c("parameters_model", "see_parameters_model", class(params))
 
   params

--- a/R/methods_mass.R
+++ b/R/methods_mass.R
@@ -129,7 +129,7 @@ model_parameters.ridgelm <- function(model, verbose = TRUE, ...) {
   rownames(parameters) <- NULL
 
   class(parameters) <- c("parameters_model", "see_parameters_model", class(parameters))
-  attr(parameters, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(parameters, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   parameters
 }
 

--- a/R/methods_mediate.R
+++ b/R/methods_mediate.R
@@ -20,7 +20,7 @@ model_parameters.mediate <- function(model, ci = 0.95, exponentiate = FALSE, ver
   # exponentiate coefficients and SE/CI, if requested
   params <- .exponentiate_parameters(params, model, exponentiate)
 
-  attr(params, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(params, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   params <- .add_model_parameters_attributes(params, model, ci, exponentiate, verbose = verbose, ...)
   class(params) <- c("parameters_model", "see_parameters_model", class(params))
 

--- a/R/methods_merTools.R
+++ b/R/methods_merTools.R
@@ -18,7 +18,7 @@ model_parameters.merModList <- function(model,
     ...
   )
 
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }
 

--- a/R/methods_metafor.R
+++ b/R/methods_metafor.R
@@ -147,7 +147,7 @@ model_parameters.rma <- function(model,
 
   # no df
   out$df_error <- NULL
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   attr(out, "measure") <- model$measure
 
   if (!"Method" %in% names(out)) {

--- a/R/methods_metaplus.R
+++ b/R/methods_metaplus.R
@@ -86,7 +86,7 @@ model_parameters.metaplus <- function(model,
 
   # no df
   out$df_error <- NULL
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   attr(out, "measure") <- "Estimate"
 
   if (!"Method" %in% names(out)) {
@@ -233,7 +233,7 @@ model_parameters.meta_random <- function(model,
 
   # final atributes
   attr(out, "measure") <- "Estimate"
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   class(out) <- c("parameters_model", "see_parameters_model", class(params))
 
   if (!"Method" %in% names(out)) {
@@ -379,7 +379,7 @@ model_parameters.meta_bma <- function(model,
 
   # final attributes
   attr(out, "measure") <- "Estimate"
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   class(out) <- c("parameters_model", "see_parameters_model", class(params))
 
   if (!"Method" %in% names(out)) {

--- a/R/methods_mfx.R
+++ b/R/methods_mfx.R
@@ -61,7 +61,7 @@ model_parameters.poissonmfx <- function(model,
     ...
   )
 
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }
 
@@ -134,7 +134,7 @@ model_parameters.betamfx <- function(model,
     ...
   )
 
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }
 

--- a/R/methods_mhurdle.R
+++ b/R/methods_mhurdle.R
@@ -22,7 +22,7 @@ model_parameters.mhurdle <- function(model,
   )
   params$Parameter <- gsub("^(h1|h2|h3)\\.(.*)", "\\2", params$Parameter)
 
-  attr(params, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(params, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   params
 }
 
@@ -93,6 +93,6 @@ simulate_model.mhurdle <- function(model, iterations = 1000, component = c("all"
   out <- .simulate_model(model, iterations, component = component, effects = "fixed", ...)
 
   class(out) <- c("parameters_simulate_model", class(out))
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }

--- a/R/methods_mice.R
+++ b/R/methods_mice.R
@@ -143,6 +143,6 @@ model_parameters.mira <- function(model,
     ...
   )
 
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }

--- a/R/methods_mixor.R
+++ b/R/methods_mixor.R
@@ -36,7 +36,7 @@ model_parameters.mixor <- function(model,
     ...
   )
 
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
 
   out
 }
@@ -83,6 +83,6 @@ simulate_model.mixor <- function(model, iterations = 1000, effects = "all", ...)
   out <- .simulate_model(model, iterations, component = "conditional", effects = effects, ...)
 
   class(out) <- c("parameters_simulate_model", class(out))
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }

--- a/R/methods_mjoint.R
+++ b/R/methods_mjoint.R
@@ -78,7 +78,7 @@ model_parameters.mjoint <- function(model,
     ...
   )
 
-  attr(params, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(params, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   class(params) <- c("parameters_model", "see_parameters_model", class(params))
 
   params

--- a/R/methods_mlm.R
+++ b/R/methods_mlm.R
@@ -59,7 +59,7 @@ model_parameters.mlm <- function(model,
     p_adjust = p_adjust,
     ...
   )
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }
 
@@ -186,7 +186,7 @@ simulate_model.mlm <- function(model, iterations = 1000, ...) {
   colnames(out) <- cn
 
   class(out) <- c("parameters_simulate_model", class(out))
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }
 
@@ -218,7 +218,7 @@ simulate_parameters.mlm <- function(model,
   }
 
   class(out) <- c("parameters_simulate", "see_parameters_simulate", class(out))
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   attr(out, "object_class") <- class(model)
   attr(out, "iterations") <- iterations
   attr(out, "ci") <- ci

--- a/R/methods_multcomp.R
+++ b/R/methods_multcomp.R
@@ -55,7 +55,7 @@ model_parameters.glht <- function(model,
   )
 
   attr(out, "p_adjust") <- p_adjust
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }
 

--- a/R/methods_mvord.R
+++ b/R/methods_mvord.R
@@ -26,7 +26,7 @@ model_parameters.mvord <- function(model,
     p_adjust = p_adjust,
     ...
   )
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }
 
@@ -89,6 +89,6 @@ simulate_model.mvord <- function(model, iterations = 1000, component = c("all", 
   out <- .simulate_model(model, iterations, component = component, ...)
 
   class(out) <- c("parameters_simulate_model", class(out))
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }

--- a/R/methods_ordinal.R
+++ b/R/methods_ordinal.R
@@ -35,7 +35,7 @@ model_parameters.clm2 <- function(model,
     ...
   )
 
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }
 
@@ -133,7 +133,7 @@ simulate_model.clm2 <- function(model,
   out <- .simulate_model(model, iterations, component = component, ...)
 
   class(out) <- c("parameters_simulate_model", class(out))
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }
 

--- a/R/methods_panelr.R
+++ b/R/methods_panelr.R
@@ -37,7 +37,7 @@ model_parameters.wbm <- function(model,
     ...
   )
 
-  attr(params, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(params, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   class(params) <- c("parameters_model", "see_parameters_model", "data.frame")
 
 

--- a/R/methods_plm.R
+++ b/R/methods_plm.R
@@ -85,7 +85,7 @@ model_parameters.pgmm <- function(model,
     verbose = verbose,
     ...
   )
-  attr(params, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(params, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   class(params) <- c("parameters_model", "see_parameters_model", class(params))
 
   params

--- a/R/methods_posterior.R
+++ b/R/methods_posterior.R
@@ -34,7 +34,7 @@ model_parameters.draws <- function(model,
   )
 
   attr(params, "ci") <- ci
-  attr(params, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(params, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   class(params) <- c("parameters_model", "see_parameters_model", class(params))
 
   params

--- a/R/methods_pscl.R
+++ b/R/methods_pscl.R
@@ -221,7 +221,7 @@ simulate_parameters.zeroinfl <- function(model,
   }
 
   class(out) <- c("parameters_simulate", "see_parameters_simulate", class(out))
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   attr(out, "iterations") <- iterations
   attr(out, "ci") <- ci
   attr(out, "ci_method") <- ci_method

--- a/R/methods_quantreg.R
+++ b/R/methods_quantreg.R
@@ -29,7 +29,7 @@ model_parameters.rqs <- function(model,
     ...
   )
 
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }
 

--- a/R/methods_rstan.R
+++ b/R/methods_rstan.R
@@ -59,7 +59,7 @@ model_parameters.stanfit <- function(model,
   )
 
   attr(params, "parameter_info") <- insight::clean_parameters(model)
-  attr(params, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(params, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   class(params) <- c("parameters_stan", "parameters_model", "see_parameters_model", class(params))
 
   params

--- a/R/methods_rstanarm.R
+++ b/R/methods_rstanarm.R
@@ -124,7 +124,7 @@ model_parameters.stanreg <- function(model,
   )
 
   attr(params, "parameter_info") <- insight::clean_parameters(model)
-  attr(params, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(params, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   class(params) <- c("parameters_stan", "parameters_model", "see_parameters_model", class(params))
 
   params
@@ -174,7 +174,7 @@ model_parameters.stanmvreg <- function(model,
   params <- .add_pretty_names(params, model)
 
   attr(params, "ci") <- ci
-  attr(params, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(params, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   class(params) <- c("parameters_model", "see_parameters_model", class(params))
 
   params

--- a/R/methods_selection.R
+++ b/R/methods_selection.R
@@ -24,7 +24,7 @@ model_parameters.selection <- function(model,
     ...
   )
 
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }
 
@@ -84,7 +84,7 @@ simulate_model.selection <- function(model, iterations = 1000, component = c("al
   out <- .simulate_model(model, iterations, component = component, effects = "fixed", ...)
 
   class(out) <- c("parameters_simulate_model", class(out))
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }
 

--- a/R/methods_survey.R
+++ b/R/methods_survey.R
@@ -31,7 +31,7 @@ model_parameters.svyglm <- function(model,
     ...
   )
 
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }
 

--- a/R/methods_systemfit.R
+++ b/R/methods_systemfit.R
@@ -25,7 +25,7 @@ model_parameters.systemfit <- function(model,
     ...
   )
 
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }
 

--- a/R/methods_varest.R
+++ b/R/methods_varest.R
@@ -28,7 +28,7 @@ model_parameters.varest <- function(model,
   })
 
   params <- do.call(rbind, params)
-  attr(params, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(params, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   params
 }
 
@@ -79,7 +79,7 @@ simulate_model.varest <- function(model, iterations = 1000, ...) {
     simulate_model(model = model$varresult[[i]], iterations = iterations, ...)
   })
   names(out) <- paste0("Equation ", names(model$varresult))
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   out
 }
 
@@ -109,7 +109,7 @@ simulate_parameters.varest <- function(model,
 
   out <- do.call(rbind, out)
   class(out) <- c("parameters_simulate", "see_parameters_simulate", class(out))
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   attr(out, "iterations") <- iterations
   attr(out, "ci") <- ci
   attr(out, "ci_method") <- ci_method

--- a/R/pool_parameters.R
+++ b/R/pool_parameters.R
@@ -59,7 +59,7 @@ pool_parameters <- function(x,
   # check input, save original model -----
 
   original_model <- random_params <- NULL
-  obj_name <- insight::safe_deparse_substitute(x)
+  obj_name <- insight::safe_deparse_symbol(substitute(x))
 
   if (all(sapply(x, insight::is_model)) && all(sapply(x, insight::is_model_supported))) {
     original_model <- x[[1]]

--- a/R/principal_components.R
+++ b/R/principal_components.R
@@ -253,7 +253,7 @@ principal_components.data.frame <- function(x,
                                             standardize = TRUE,
                                             ...) {
   # save name of data set
-  data_name <- insight::safe_deparse_substitute(x)
+  data_name <- insight::safe_deparse_symbol(substitute(x))
 
   # original data
   original_data <- x

--- a/R/print.parameters_model.R
+++ b/R/print.parameters_model.R
@@ -82,6 +82,10 @@
 #' and value labels for pretty names, if data is labelled. If no labels
 #' available, default pretty names are used.
 #'
+#' - `parameters_interaction`: `options(parameters_interaction = "*")` will
+#' replace the separator for interactions (by default, `*`) with the related
+#' character.
+#'
 #' - `parameters_select`: `options(parameters_select = <value>)` will set the
 #' default for the `select` argument. See argument's documentation for available
 #' options.

--- a/R/simulate_parameters.R
+++ b/R/simulate_parameters.R
@@ -86,7 +86,7 @@ simulate_parameters.default <- function(model,
   }
 
   class(out) <- c("parameters_simulate", "see_parameters_simulate", class(out))
-  attr(out, "object_name") <- insight::safe_deparse_substitute(model)
+  attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
   attr(out, "iterations") <- iterations
   attr(out, "ci") <- ci
   attr(out, "ci_method") <- ci_method

--- a/R/standardize_parameters.R
+++ b/R/standardize_parameters.R
@@ -190,7 +190,7 @@ standardize_parameters.default <- function(model,
   # check for valid input
   .is_model_valid(model)
 
-  object_name <- insight::safe_deparse_substitute(model)
+  object_name <- insight::safe_deparse_symbol(substitute(model))
   method <- match.arg(method, c("refit", "posthoc", "smart", "basic", "classic", "pseudo"))
 
   m_info <- .get_model_info(model, ...)
@@ -343,7 +343,7 @@ standardize_parameters.bootstrap_model <- function(model,
                                                    include_response = TRUE,
                                                    verbose = TRUE,
                                                    ...) {
-  object_name <- insight::safe_deparse_substitute(model)
+  object_name <- insight::safe_deparse_symbol(substitute(model))
   method <- match.arg(method, c("refit", "posthoc", "smart", "basic", "classic", "pseudo"))
 
   pars <- model

--- a/R/standardize_posteriors.R
+++ b/R/standardize_posteriors.R
@@ -8,7 +8,7 @@ standardize_posteriors <- function(model,
                                    include_response = TRUE,
                                    verbose = TRUE,
                                    ...) {
-  object_name <- insight::safe_deparse_substitute(model)
+  object_name <- insight::safe_deparse_symbol(substitute(model))
 
   m_info <- .get_model_info(model, ...)
   include_response <- include_response && .safe_to_standardize_response(m_info, verbose = verbose)

--- a/R/utils_model_parameters.R
+++ b/R/utils_model_parameters.R
@@ -37,7 +37,7 @@
   if (isFALSE(dot.arguments$pretty_names)) {
     attr(params, "pretty_names") <- params$Parameter
   } else if (is.null(attr(params, "pretty_names", exact = TRUE))) {
-    attr(params, "pretty_names") <- suppressWarnings(format_parameters(model, model_info = info))
+    attr(params, "pretty_names") <- suppressWarnings(format_parameters(model, model_info = info, ...))
   }
 
   attr(params, "ci") <- ci

--- a/man/model_parameters.Rd
+++ b/man/model_parameters.Rd
@@ -358,6 +358,9 @@ to \code{FALSE} to hide this message when printing \code{model_parameters()} obj
 \item \code{parameters_labels}: \code{options(parameters_labels = TRUE)} will use variable
 and value labels for pretty names, if data is labelled. If no labels
 available, default pretty names are used.
+\item \code{parameters_interaction}: \code{options(parameters_interaction = "*")} will
+replace the separator for interactions (by default, \code{*}) with the related
+character.
 \item \code{parameters_select}: \verb{options(parameters_select = <value>)} will set the
 default for the \code{select} argument. See argument's documentation for available
 options.

--- a/man/print.parameters_model.Rd
+++ b/man/print.parameters_model.Rd
@@ -129,6 +129,9 @@ to \code{FALSE} to hide this message when printing \code{model_parameters()} obj
 \item \code{parameters_labels}: \code{options(parameters_labels = TRUE)} will use variable
 and value labels for pretty names, if data is labelled. If no labels
 available, default pretty names are used.
+\item \code{parameters_interaction}: \code{options(parameters_interaction = "*")} will
+replace the separator for interactions (by default, \code{*}) with the related
+character.
 \item \code{parameters_select}: \verb{options(parameters_select = <value>)} will set the
 default for the \code{select} argument. See argument's documentation for available
 options.


### PR DESCRIPTION
Looks better than with the `:`

``` r
parameters::parameters(lm(Sepal.Length ~ Species * Sepal.Width, data = iris))
#> Parameter                          | Coefficient |   SE |        95% CI | t(144) |      p
#> -----------------------------------------------------------------------------------------
#> (Intercept)                        |        2.64 | 0.57 | [ 1.51, 3.77] |   4.62 | < .001
#> Species [versicolor]               |        0.90 | 0.80 | [-0.68, 2.48] |   1.13 | 0.261 
#> Species [virginica]                |        1.27 | 0.82 | [-0.35, 2.88] |   1.55 | 0.123 
#> Sepal Width                        |        0.69 | 0.17 | [ 0.36, 1.02] |   4.17 | < .001
#> Species [versicolor] x Sepal Width |        0.17 | 0.26 | [-0.34, 0.69] |   0.67 | 0.503 
#> Species [virginica] x Sepal Width  |        0.21 | 0.26 | [-0.29, 0.72] |   0.83 | 0.411
#> 
#> Uncertainty intervals (equal-tailed) and p-values (two-tailed) computed
#>   using a Wald t-distribution approximation.
```

<sup>Created on 2022-10-11 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
