### PR TITLE
Correct typo in Standardized Associations section

### DIFF
--- a/vignettes/standardize_parameters_effsize.Rmd
+++ b/vignettes/standardize_parameters_effsize.Rmd
@@ -72,7 +72,7 @@ standardize_parameters(m)
 ```
 
 Standardizing the coefficient of this *simple* linear regression gives a value
-of `0.87`, but did you know that for a simple regression this is actually the
+of `r round(standardize_parameters(m)[2,2],2)`, but did you know that for a simple regression this is actually the
 **same as a correlation**? Thus, you can eventually apply some (*in*)famous
 interpretation guidelines (e.g., Cohen's rules of thumb).
 


### PR DESCRIPTION
In the `Standardized Associations` section, it said

> Standardizing the coefficient of this *simple* linear regression gives a value of `0.87`

but the computed value is 0.83, not 0.87.  So replaced the 0.87 with inline R code that will compute the 0.83 automatically.