### PR TITLE
Detach merDeriv on exit

### DIFF
--- a/R/extract_random_variances.R
+++ b/R/extract_random_variances.R
@@ -380,6 +380,12 @@ as.data.frame.VarCorr.lme <- function(x, row.names = NULL, optional = FALSE, ...
       # lme4 - wald / normal CI
 
       merDeriv_loaded <- isNamespaceLoaded("merDeriv")
+      # detach on exit
+      on.exit({
+        if (!merDeriv_loaded) {
+          .unregister_vcov()
+        }
+      })
 
       # Wald based CIs
       # see https://stat.ethz.ch/pipermail/r-sig-mixed-models/2022q1/029985.html
@@ -504,11 +510,6 @@ as.data.frame.VarCorr.lme <- function(x, row.names = NULL, optional = FALSE, ...
             out
           }
         )
-
-        # detach
-        if (!merDeriv_loaded) {
-          .unregister_vcov()
-        }
       } else if (isTRUE(verbose)) {
         insight::format_alert("Package 'merDeriv' needs to be installed to compute confidence intervals for random effect parameters.")
       }


### PR DESCRIPTION
I am dumb, and so this is something I do a lot:

1. run `model_parameters(ci_random = TRUE)` on an LMM
2. Wait for 5 seconds
3. Get impatient
4. Press `stop`
5. **`merDeriv` is still attached!**

This happens because unfortunately, behind the scenes, this is what happens:
1. `merDeriv` is attached
2. Computation is aborted before the line that detaches `merDeriv` is reached.

This PR moves the detaching function into an `on.exit()` call. This means that the detaching will happen when the function is exited no matter what - a failure or the user aborting the operation.

So now:

1. run `model_parameters(ci_random = TRUE)` on an LMM
2. Wait for 5 seconds
3. Get impatient
4. Press `stop`
5. **`merDeriv` is detached** on function exit.
