### PR TITLE
Updated method look-ups and factor variable support for `dominance_analysis`

### DIFF
--- a/R/dominance_analysis.R
+++ b/R/dominance_analysis.R
@@ -73,8 +73,9 @@
 #' complete dominance designations.
 #'
 #' The input model is parsed using `insight::find_predictors()`, does not
-#' yet support interactions, transformations, or offsets applied in the
-#' R formula, and will fail with an error if any such terms are detected.
+#' yet support interactions, transformations, factor variables created by
+#' [`model.matrix()`] or offsets applied in the R formula, and will fail
+#' with an error if any such terms are detected.
 #'
 #' The model submitted must accept an formula object as a `formula`
 #' argument.  In addition, the model object must accept the data on which
@@ -90,10 +91,6 @@
 #'
 #' When `performance::r2()` returns multiple values, only the first is used
 #' by default.
-#'
-#' The underlying `domir::domin()` function that implements the dominance
-#' statistic and designation computations has only been tested to R version
-#' 3.5 and will fail with an error if called in R versions < 3.5.
 #'
 #' @references
 #' - Azen, R., & Budescu, D. V. (2003). The dominance analysis approach
@@ -113,8 +110,7 @@
 #' @author Joseph Luchman
 #'
 #' @examples
-#' if (getRversion() >= "3.5.0" && require("domir") &&
-#'   require("performance")) {
+#' if (require("domir") && require("performance")) {
 #'   data(mtcars)
 #'
 #'   # Dominance Analysis with Logit Regression
@@ -146,8 +142,8 @@ dominance_analysis <- function(model, sets = NULL, all = NULL,
     )
   }
 
-  if (!any(utils::.S3methods("r2", class = class(model)[[1]], envir = getNamespace("performance")) ==
-    paste0("r2.", class(model)[[1]]))) {
+  if (!any(utils::.S3methods("r2", class = class(model)[[1]], envir = getNamespace("performance")) %in%
+    paste0("r2.", class(model)))) {
     insight::format_error(
       paste(deparse(substitute(model)), "does not have a {.pkg perfomance}-supported `r2()` method."),
       "You may be able to dominance analyze this model using the {.pkg domir} package."
@@ -157,28 +153,32 @@ dominance_analysis <- function(model, sets = NULL, all = NULL,
   model_info <- insight::model_info(model)
   if (any(unlist(model_info[c("is_bayesian", "is_mixed", "is_gam", "is_multivariate", "is_zero_inflated", "is_hurdle")]))) {
     insight::format_error(
-      paste0("`dominance_analysis()` does not yet support models of class `", class(model), "`."),
+      paste0("`dominance_analysis()` does not yet support models of class `", class(model)[[1]], "`."),
       "You may be able to dominance analyze this model using the {.pkg domir} package."
+    )
+  }
+
+  if (length(insight::find_predictors(model, flatten = TRUE)) < 2) {
+    insight::format_error("Too few predictors for a dominance analysis.")
+  }
+
+  if (!is.null(insight::find_offset(model))) {
+    insight::format_error("Offsets in the model are not allowed in this version of `dominance_analysis()`.",
+                          "Try using package {.pkg domir}.")
+  }
+
+  if (!all(insight::find_predictors(model, flatten = TRUE) %in% insight::find_parameters(model, flatten = TRUE))) {
+    insight::format_error(
+      "Predictors do not match terms.",
+      "This usually occurs when there are in-formula predictor transformations such as `log(x)` or `I(x+z)`",
+      "or when a factor variable is processed using R's internal `model.matrix()` functions to get indicator codes.",
+      "`dominance_analysis()` cannot yet accommodate such terms. Reformat your model to ensure all parameters",
+      "match predictors in the data or use the {.pkg domir} package."
     )
   }
 
   if (!is.null(insight::find_interactions(model))) {
     insight::format_error("Interactions in the model formula are not allowed.")
-  }
-
-  if (!all(insight::find_predictors(model)$conditional %in% attr(stats::terms(insight::find_formula(model)$conditional), "term.labels"))) {
-    insight::format_error(
-      "Predictors do not match terms.",
-      "This usually occurs when there are in-formula predictor transformations such as `log(x)` or `I(x+z).`"
-    )
-  }
-
-  if (!is.null(insight::find_offset(model))) {
-    insight::format_error("Offsets in the model formula are not allowed.")
-  }
-
-  if (getRversion() < "3.5") {
-    insight::format_error("R versions < 3.5 not supported.")
   }
 
   if (!is.null(sets)) {
@@ -218,7 +218,8 @@ dominance_analysis <- function(model, sets = NULL, all = NULL,
 
   dv <- insight::find_response(model)
 
-  reg <- insight::model_name(model)
+  #reg <- insight::model_name(model) # insight::get_call + as.list() and take first element? glm.nb doesn't work...
+  reg <- as.list(insight::get_call(model))[[1]]
 
   # Process sets ----
   if (!is.null(sets)) {
@@ -278,7 +279,8 @@ dominance_analysis <- function(model, sets = NULL, all = NULL,
     all_remove_loc <- which(ivs %in% all_processed)
 
     if (any(all_processed %in% unlist(sets_processed))) {
-      reused_terms <- all_processed[which(all_processed %in% unlist(sets_processed))]
+      reused_terms <-
+        all_processed[which(all_processed %in% unlist(sets_processed))]
 
       insight::format_error(
         "Terms",
@@ -341,7 +343,8 @@ dominance_analysis <- function(model, sets = NULL, all = NULL,
     if (!(arg %in% names(args))) {
       insight::format_error(arg, " in `quote_args` not among arguments in model.")
     } else {
-      args[[arg]] <- str2lang(paste0("quote(", deparse(args[[arg]]), ")", collapse = ""))
+      args[[arg]] <-
+        str2lang(paste0("quote(", deparse(args[[arg]]), ")", collapse = ""))
     }
   }
 
@@ -360,20 +363,25 @@ dominance_analysis <- function(model, sets = NULL, all = NULL,
   utils::capture.output(domir_res <- do.call(domir::domin, args2domin))
 
   # Set up returned data.frames ----
+  # Apply set names to domin results
   if (!is.null(sets)) {
     names(domir_res$General_Dominance) <-
       c(
-        names(domir_res$General_Dominance)[1:(length(domir_res$General_Dominance) - length(set_names))],
+        names(domir_res$General_Dominance)[
+          1:(length(domir_res$General_Dominance) - length(set_names))
+          ],
         set_names
       )
 
     if (conditional) {
-      rownames(domir_res$Conditional_Dominance) <- names(domir_res$General_Dominance)
+      rownames(domir_res$Conditional_Dominance) <-
+        names(domir_res$General_Dominance)
     }
   }
 
   if (complete) {
-    colnames(domir_res$Complete_Dominance) <- paste0("dmn_", names(domir_res$General_Dominance))
+    colnames(domir_res$Complete_Dominance) <-
+      paste0("dmn_", names(domir_res$General_Dominance))
 
     dimnames(domir_res$Complete_Dominance) <- list(
       colnames(domir_res$Complete_Dominance),
@@ -383,11 +391,23 @@ dominance_analysis <- function(model, sets = NULL, all = NULL,
     domir_res$Complete_Dominance <- t(domir_res$Complete_Dominance)
   }
 
-  da_df_res <- da_df_cat <-
+  # Map parameter names to subsets - structure set-up
+  da_df_res <-
+    da_df_cat <-
     .data_frame(parameter = insight::find_parameters(model, flatten = TRUE))
 
   da_df_cat <- .data_frame(da_df_cat, subset = NA_character_)
 
+  # if parameter is same as domin name, copy it to 'subset'
+  da_df_cat$subset <-
+    ifelse((da_df_res$parameter %in%
+              names(domir_res$General_Dominance)) &
+             (is.na(da_df_cat$subset)),
+           da_df_res$parameter,
+           da_df_cat$subset
+    )
+
+  # Apply set names
   if (!is.null(sets)) {
     for (set in seq_along(sets)) {
       set_name <- if (!is.null(names(sets)[[set]])) {
@@ -402,8 +422,10 @@ dominance_analysis <- function(model, sets = NULL, all = NULL,
           da_df_res$parameter %in% all.vars(sets[[set]]), set_name
         )
     }
+
   }
 
+  # Apply 'all' names
   if (!is.null(all)) {
     da_df_cat$subset <-
       replace(
@@ -412,19 +434,14 @@ dominance_analysis <- function(model, sets = NULL, all = NULL,
       )
   }
 
-  da_df_cat$subset <-
-    ifelse((da_df_res$parameter %in% (insight::find_predictors(model, flatten = TRUE))) &
-      (is.na(da_df_cat$subset)),
-    da_df_res$parameter,
-    da_df_cat$subset
-    )
-
+  # assume remaining parameters are part of 'constant'
   da_df_cat$subset <-
     replace(
       da_df_cat$subset,
       is.na(da_df_cat$subset), "constant"
     )
 
+  # merge subsets and DA results to parameter names
   da_df_res <-
     datawizard::data_merge(
       da_df_cat,
@@ -434,11 +451,15 @@ dominance_analysis <- function(model, sets = NULL, all = NULL,
       )
     )
 
+  # plug in value of 'all' in 'all' subsets/parameters
   if (!is.null(all)) {
     da_df_res$general_dominance <-
-      replace(da_df_res$general_dominance, da_df_res$subset == "all", domir_res$Fit_Statistic_All_Subsets)
+      replace(da_df_res$general_dominance,
+              da_df_res$subset == "all",
+              domir_res$Fit_Statistic_All_Subsets)
   }
 
+  # merge standardized general dominance stat values
   da_df_res <-
     datawizard::data_merge(
       da_df_res,
@@ -448,6 +469,7 @@ dominance_analysis <- function(model, sets = NULL, all = NULL,
       )
     )
 
+  # merge  ranks based on general dominance stat values
   da_df_res <-
     datawizard::data_merge(
       da_df_res,

--- a/R/dominance_analysis.R
+++ b/R/dominance_analysis.R
@@ -422,11 +422,11 @@ dominance_analysis <- function(model, sets = NULL, all = NULL,
         names(contrasts),
         function(name) {
           pred_loc <-
-            which(find_predictors(model, flatten = TRUE)==name)
+            which(insight::find_predictors(model, flatten = TRUE)==name)
 
           pred_names <-
-            colnames(get_modelmatrix(model))[
-              which(attr(get_modelmatrix(model), "assign")==pred_loc)
+            colnames(insight::get_modelmatrix(model))[
+              which(attr(insight::get_modelmatrix(model), "assign")==pred_loc)
             ]
         }
       )

--- a/man/dominance_analysis.Rd
+++ b/man/dominance_analysis.Rd
@@ -97,8 +97,9 @@ therefore does not receive a rank, conditional dominance statistics, or
 complete dominance designations.
 
 The input model is parsed using \code{insight::find_predictors()}, does not
-yet support interactions, transformations, or offsets applied in the
-R formula, and will fail with an error if any such terms are detected.
+yet support interactions, transformations, factor variables created by
+\code{\link[=model.matrix]{model.matrix()}} or offsets applied in the R formula, and will fail
+with an error if any such terms are detected.
 
 The model submitted must accept an formula object as a \code{formula}
 argument.  In addition, the model object must accept the data on which
@@ -114,14 +115,9 @@ or "is_hurdle" are not supported at current.
 
 When \code{performance::r2()} returns multiple values, only the first is used
 by default.
-
-The underlying \code{domir::domin()} function that implements the dominance
-statistic and designation computations has only been tested to R version
-3.5 and will fail with an error if called in R versions < 3.5.
 }
 \examples{
-if (getRversion() >= "3.5.0" && require("domir") &&
-  require("performance")) {
+if (require("domir") && require("performance")) {
   data(mtcars)
 
   # Dominance Analysis with Logit Regression

--- a/man/dominance_analysis.Rd
+++ b/man/dominance_analysis.Rd
@@ -11,6 +11,7 @@ dominance_analysis(
   conditional = TRUE,
   complete = TRUE,
   quote_args = NULL,
+  contrasts = model$contrasts,
   ...
 )
 }
@@ -47,6 +48,13 @@ If complete dominance is not desired as an importance criterion, avoiding comput
 is necessary for data masked arguments (e.g., \code{weights}) to prevent them
 from being evaluated before being applied to the model and causing an error.}
 
+\item{contrasts}{A named list of \code{\link{contrasts}} used by the model object.
+This list is required in order for the correct mapping of parameters to
+predictors in the output when the model creates indicator codes for factor
+variables using \code{\link{model_matrix}}. By default, the \code{contrast} element from
+the model object submitted is used. If the model object does not have a
+\code{contrast} element the user can supply this named list.}
+
 \item{...}{Not used at current.}
 }
 \value{
@@ -78,7 +86,7 @@ designations. The subsets in the observations are compared to the
 subsets referenced in each variable. Whether the subset
 in each variable dominates the subset in each observation is
 represented in the  logical value. \code{NULL} if \code{complete}
-argument is \code{FALSE}..}
+argument is \code{FALSE}.}
 }
 }
 \description{
@@ -97,9 +105,8 @@ therefore does not receive a rank, conditional dominance statistics, or
 complete dominance designations.
 
 The input model is parsed using \code{insight::find_predictors()}, does not
-yet support interactions, transformations, factor variables created by
-\code{\link[=model.matrix]{model.matrix()}} or offsets applied in the R formula, and will fail
-with an error if any such terms are detected.
+yet support interactions, transformations, or offsets applied in the R
+formula, and will fail with an error if any such terms are detected.
 
 The model submitted must accept an formula object as a \code{formula}
 argument.  In addition, the model object must accept the data on which


### PR DESCRIPTION
This pull request patch is a fix to the bugs identified in #879.

The fixes to both examples in the issue report are discussed below.

First, the method lookup uses all returned classes from the model object and thus cycles through arguments in a way similar to `NextMethod()` which fixes the issue identified below and produces the intended behavior for models like`glm.nb` as is shown below (In my local 'devmode' version).

```
d> quine.nb1 |> parameters::dominance_analysis()

d> quine.nb1 |> parameters::dominance_analysis(quote_args = "link")
# Dominance Analysis Results

Model R2 Value:  0.210 

General Dominance Statistics

Parameter   | General Dominance | Percent | Ranks |   Subset
------------------------------------------------------------
(Intercept) |                   |         |       | constant
SexM        |             0.006 |   0.031 |     3 |      Sex
AgeF1       |             0.092 |   0.439 |     2 |      Age
AgeF2       |             0.092 |   0.439 |     2 |      Age
AgeF3       |             0.092 |   0.439 |     2 |      Age
EthN        |             0.111 |   0.530 |     1 |      Eth

Conditional Dominance Statistics

Subset | IVs: 1 | IVs: 2 | IVs: 3
---------------------------------
Sex    |  0.010 |  0.008 |  0.001
Age    |  0.101 |  0.094 |  0.082
Eth    |  0.112 |  0.113 |  0.109

Complete Dominance Designations

Subset | < Sex | < Age | < Eth
------------------------------
Sex    |       |  TRUE |  TRUE
Age    | FALSE |       |  TRUE
Eth    | FALSE | FALSE |  
```

The example above also shows how the fix to factor indicators produced by `Model.Matrix()` look as implemented. 

To extend on this idea, the example I provide below expands on the second bug discussed in the issue report as well and shows how the contrasts are accommodated. 

The fix involves a new argument to `dominance_analysis()` called `contrasts` that maps the contrasts to variable names for display purposes. As is implied by the results from the `glm.nb` model above, this process automatically pipes the `model` submitted to `dominance_analysis()` to the `contrasts` argument and uses the element `contrasts` from this model. 

```
d> mtcars |> transform(cyl = as.factor(cyl)) |> lm(mpg ~ cyl + am + qsec, data = _) |> 
     (\(model) {parameters::dominance_analysis(model, contrasts = model$contrasts) } )()
# Dominance Analysis Results

Model R2 Value:  0.769 

General Dominance Statistics

Parameter   | General Dominance | Percent | Ranks |   Subset
------------------------------------------------------------
(Intercept) |                   |         |       | constant
cyl6        |             0.434 |   0.564 |     1 |      cyl
cyl8        |             0.434 |   0.564 |     1 |      cyl
am          |             0.219 |   0.285 |     2 |       am
qsec        |             0.116 |   0.151 |     3 |     qsec

Conditional Dominance Statistics

Subset | IVs: 1 | IVs: 2 | IVs: 3
---------------------------------
cyl    |  0.732 |  0.487 |  0.082
am     |  0.360 |  0.272 |  0.025
qsec   |  0.175 |  0.169 |  0.003

Complete Dominance Designations

Subset | < cyl |  < am | < qsec
-------------------------------
cyl    |       | FALSE |  FALSE
am     |  TRUE |       |  FALSE
qsec   |  TRUE |  TRUE |       
```

