### PR TITLE
Warn (in model_parameters) when argument is not supported by method?

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: parameters
 Title: Processing of Model Parameters
-Version: 0.21.3.6
+Version: 0.21.3.7
 Authors@R:
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,9 @@
 * `n_factors()` now also returns the explained variance for the number of
   factors as attributes.
 
+* `model_parameters()` for objects of package *metafor* now warns when unsupported
+  arguments (like `vcov`) are used.
+
 ## Bug fixes
 
 * `print(include_reference = TRUE)` for `model_parameters()` did not work when

--- a/R/methods_metafor.R
+++ b/R/methods_metafor.R
@@ -65,6 +65,14 @@ model_parameters.rma <- function(model,
     ci <- ci_level / 100
   }
 
+  # validation check, warn if unsupported argument is used.
+  .check_dots(
+    dots = list(...),
+    not_allowed = c("vcov", "vcov_args"),
+    class(model)[1],
+    verbose = verbose
+  )
+
   meta_analysis_overall <- .model_parameters_generic(
     model = model,
     ci = ci,

--- a/tests/testthat/test-model_parameters.metafor.R
+++ b/tests/testthat/test-model_parameters.metafor.R
@@ -18,4 +18,9 @@ test_that("model_parameters.metafor", {
   )
   expect_equal(params$Coefficient, c(0.111, 0.245, 0.8, 1.1, 0.03, 0.43769), tolerance = 1e-3)
   expect_equal(params$Weight, c(400, 81.16224, 1e+06, 25, 10000, NA), tolerance = 1e-3)
+  # test message on unsupported arguments
+  expect_message(model_parameters(model, vcov = "vcovHC"), regex = "Following arguments")
+  # test standardize
+  params <- model_parameters(model, standardize = "refit")
+  expect_equal(params$Coefficient, c(0.111, 0.245, 0.8, 1.1, 0.03, -0.5613041), tolerance = 1e-3)
 })


### PR DESCRIPTION
Fixes #930