### PR TITLE
marginaleffects_0_18_0

### DIFF
--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,3 +1,3 @@
-Version: 0.21.4
-Date: 2024-02-03 21:38:27 UTC
-SHA: 48a16ce752065c5b09eff5cbb5ecd3c22c2bc32d
+Version: 0.21.5
+Date: 2024-02-05 20:27:13 UTC
+SHA: 00b4bebae447c23d7e1663ceac675a9d4329aa24

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: parameters
 Title: Processing of Model Parameters
-Version: 0.21.4
+Version: 0.21.5
 Authors@R:
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# parameters 0.21.5
+
+## Bug fixes
+
+* Fixes CRAN check errors related to the changes in the latest update of
+  *marginaleffects*.
+
 # parameters 0.21.4
 
 ## Breaking changes

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,3 @@
 Hotfix to address errors in CRAN checks related to the last *marginaleffects* update.
 
-Not that this update still breaks the *see* package, since the previous submission of *parameters* was just yesterday. An update of the *see* package will submitted once this submission is accepted on CRAN.
+Not that this update still breaks the *see* package, since the previous submission of *parameters* was just yesterday - sorry for the bad timing! An update of the *see* package will submitted once this submission is accepted on CRAN.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,10 +1,3 @@
-Maintainance release.
+Hotfix to address errors in CRAN checks related to the last *marginaleffects* update.
 
-## revdepcheck results
-
-We checked 33 reverse dependencies (27 from CRAN + 6 from Bioconductor), comparing R CMD check results across CRAN and dev versions of this package.
-
- * We saw 1 new problems
- * We failed to check 0 packages
- 
-This update breaks the *see* package. The maintainer is informed and prepared a fix, which is ready to be submitted once this submission is accepted on CRAN.
+Not that this update still breaks the *see* package, since the previous submission of *parameters* was just yesterday. An update of the *see* package will submitted once this submission is accepted on CRAN.

--- a/tests/testthat/test-marginaleffects.R
+++ b/tests/testthat/test-marginaleffects.R
@@ -1,4 +1,4 @@
-skip_if_not_installed("marginaleffects", minimum_version = "0.15.0")
+skip_if_not_installed("marginaleffects", minimum_version = "0.18.0")
 skip_if_not_installed("rstanarm")
 
 test_that("marginaleffects()", {

--- a/tests/testthat/test-marginaleffects.R
+++ b/tests/testthat/test-marginaleffects.R
@@ -4,12 +4,12 @@ skip_if_not_installed("rstanarm")
 test_that("marginaleffects()", {
   # Frequentist
   x <- lm(Sepal.Width ~ Species * Petal.Length, data = iris)
-  model <- marginaleffects::slopes(x, newdata = insight::get_datagrid(x, at = "Species"), variables = "Petal.Length")
+  model <- marginaleffects::avg_slopes(x, newdata = insight::get_datagrid(x, at = "Species"), variables = "Petal.Length")
   out <- parameters(model)
   expect_identical(nrow(out), 1L)
   expect_named(out, c(
-    "Parameter", "Comparison", "Coefficient", "SE", "Statistic",
-    "p", "CI", "CI_low", "CI_high"
+    "Parameter", "Coefficient", "SE", "Statistic",
+    "p", "s.value", "CI", "CI_low", "CI_high"
   ))
   out <- model_parameters(model, exponentiate = TRUE)
   expect_equal(out$Coefficient, 1.394, tolerance = 1e-3)
@@ -24,7 +24,7 @@ test_that("marginaleffects()", {
       chains = 1
     )
   )
-  model <- marginaleffects::slopes(x, newdata = insight::get_datagrid(x, at = "Species"), variables = "Petal.Length")
+  model <- marginaleffects::avg_slopes(x, newdata = insight::get_datagrid(x, at = "Species"), variables = "Petal.Length")
   expect_identical(nrow(parameters(model)), 1L)
 })
 
@@ -47,7 +47,7 @@ test_that("comparisons()", {
   data(iris)
   # Frequentist
   x <- lm(Sepal.Width ~ Species * Petal.Length, data = iris)
-  m <- marginaleffects::comparisons(x, newdata = insight::get_datagrid(x, at = "Species"), variables = "Petal.Length")
+  m <- marginaleffects::avg_comparisons(x, newdata = insight::get_datagrid(x, at = "Species"), variables = "Petal.Length")
   expect_identical(nrow(parameters(m)), 1L)
   out <- parameters(m, exponentiate = TRUE)
   expect_equal(out$Coefficient, 1.393999, tolerance = 1e-4)
@@ -62,7 +62,7 @@ test_that("comparisons()", {
       chains = 1
     )
   )
-  m <- marginaleffects::slopes(
+  m <- marginaleffects::avg_slopes(
     x,
     newdata = insight::get_datagrid(x, at = "Species"),
     variables = "Petal.Length"
@@ -70,16 +70,6 @@ test_that("comparisons()", {
   expect_identical(nrow(parameters(m)), 1L)
 })
 
-
-test_that("marginalmeans()", {
-  data(mtcars)
-  dat <- mtcars
-  dat$cyl <- factor(dat$cyl)
-  dat$gear <- factor(dat$gear)
-  x <- lm(mpg ~ cyl + gear, data = dat)
-  m <- marginaleffects::marginalmeans(x)
-  expect_identical(nrow(parameters(m)), 6L)
-})
 
 
 test_that("hypotheses()", {


### PR DESCRIPTION
Version 0.18.0 of `marginaleffects` introduces some deprecations and other minor breaking changes in preparation for the stabilization of the user "final" user interface in `marginaleffects` 1.0.0.

This PR adjusts some tests to account for this. The changes are relatively minor.