### PR TITLE
Fix row name for the prevalence ratio in methods_epi2x2.R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: parameters
 Title: Processing of Model Parameters
-Version: 0.21.5
+Version: 0.21.5.1
 Authors@R:
     c(person(given = "Daniel",
              family = "Lüdecke",
@@ -117,6 +117,7 @@ Suggests:
     effectsize (>= 0.8.6),
     EGAnet,
     emmeans (>= 1.7.0),
+    epiR,
     estimatr,
     factoextra,
     FactoMineR,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# parameters 0.21.6
+
+## Bug fixes
+
+* Fixed issue with parameter names for `model_parameters()` and objects from
+  package *epiR*.
+
 # parameters 0.21.5
 
 ## Bug fixes

--- a/R/methods_epi2x2.R
+++ b/R/methods_epi2x2.R
@@ -24,7 +24,7 @@ model_parameters.epi.2by2 <- function(model, verbose = TRUE, ...) {
 
   # pretty names
   pretty_names <- params$Parameter
-  pretty_names[pretty_names == "PR"] <- "Prevalence Ratio"
+  pretty_names[pretty_names == "RR"] <- "Prevalence Ratio"
   pretty_names[pretty_names == "OR"] <- "Odds Ratio"
   pretty_names[pretty_names == "ARisk"] <- "Attributable Risk"
   pretty_names[pretty_names == "PARisk"] <- "Attributable Risk in Population"

--- a/R/methods_epi2x2.R
+++ b/R/methods_epi2x2.R
@@ -24,7 +24,8 @@ model_parameters.epi.2by2 <- function(model, verbose = TRUE, ...) {
 
   # pretty names
   pretty_names <- params$Parameter
-  pretty_names[pretty_names == "RR"] <- "Prevalence Ratio"
+  pretty_names[pretty_names == "PR"] <- "Prevalence Ratio"
+  pretty_names[pretty_names == "RR"] <- "Risk Ratio"
   pretty_names[pretty_names == "OR"] <- "Odds Ratio"
   pretty_names[pretty_names == "ARisk"] <- "Attributable Risk"
   pretty_names[pretty_names == "PARisk"] <- "Attributable Risk in Population"

--- a/tests/testthat/test-model_parameters.aov.R
+++ b/tests/testthat/test-model_parameters.aov.R
@@ -18,7 +18,7 @@ test_that("model_parameters.aov", {
   model <- aov(Sepal.Width ~ Species, data = iris)
   mp <- suppressMessages(model_parameters(model, effectsize_type = c("omega", "eta", "epsilon")))
   expect_identical(sum(mp$df), 149)
-  expect_names(mp, c(
+  expect_named(mp, c(
     "Parameter", "Sum_Squares", "df", "Mean_Square", "F", "p",
     "Omega2", "Eta2", "Epsilon2"
   ))
@@ -33,25 +33,25 @@ test_that("model_parameters.aov", {
 test_that("model_parameters.anova", {
   skip_if_not_installed("lme4")
   model <- anova(lm(Sepal.Width ~ Species, data = iris))
-  expect_identical(sum(model_parameters(model)$df), 149)
+  expect_identical(sum(model_parameters(model)$df), 149L)
 
   model <- anova(lm(Sepal.Length ~ Species * Cat1 * Cat2, data = iris))
-  expect_identical(sum(model_parameters(model)$df), 149)
+  expect_identical(sum(model_parameters(model)$df), 149L)
 
   model <- anova(lme4::lmer(wt ~ 1 + (1 | gear), data = mtcars))
-  expect_identical(nrow(model_parameters(model)), 0)
+  expect_identical(nrow(model_parameters(model)), 0L)
 
   model <- anova(lme4::lmer(wt ~ cyl + (1 | gear), data = mtcars))
-  expect_identical(sum(model_parameters(model)$df), 1)
+  expect_identical(sum(model_parameters(model)$df), 1L)
 
   model <- anova(lme4::lmer(wt ~ drat + cyl + (1 | gear), data = mtcars))
-  expect_eexpect_identicalual(sum(model_parameters(model)$df), 2)
+  expect_identical(sum(model_parameters(model)$df), 2L)
 
   model <- anova(lme4::lmer(wt ~ drat * cyl + (1 | gear), data = mtcars))
-  expect_identical(sum(model_parameters(model, verbose = FALSE)$df), 3)
+  expect_identical(sum(model_parameters(model, verbose = FALSE)$df), 3L)
 
   model <- anova(lme4::lmer(wt ~ drat / cyl + (1 | gear), data = mtcars))
-  expect_identical(sum(model_parameters(model, verbose = FALSE)$df), 2)
+  expect_identical(sum(model_parameters(model, verbose = FALSE)$df), 2L)
 })
 
 
@@ -61,13 +61,13 @@ test_that("model_parameters.anova", {
   skip_if_not_installed("httr")
 
   model <- insight::download_model("anova_3")
-  expect_identical(sum(model_parameters(model, verbose = FALSE)$df), 149)
+  expect_identical(sum(model_parameters(model, verbose = FALSE)$df), 149L)
 
   model <- insight::download_model("anova_4")
   expect_identical(sum(model_parameters(model, verbose = FALSE)$df, na.rm = TRUE), 2)
 
   model <- insight::download_model("anova_lmerMod_5")
-  expect_identical(sum(model_parameters(model, verbose = FALSE)$df), 1)
+  expect_identical(sum(model_parameters(model, verbose = FALSE)$df), 1L)
 
   model <- insight::download_model("anova_lmerMod_6")
   expect_identical(sum(model_parameters(model, verbose = FALSE)$df), 12)

--- a/tests/testthat/test-model_parameters.aov.R
+++ b/tests/testthat/test-model_parameters.aov.R
@@ -9,7 +9,7 @@ test_that("model_parameters.aov", {
   skip_if_not_installed("effectsize", minimum_version = "0.5.0")
   model <- aov(Sepal.Width ~ Species, data = iris)
   mp <- suppressMessages(model_parameters(model, effectsize_type = c("omega", "eta", "epsilon")))
-  expect_equal(mp$Parameter, c("Species", "Residuals"))
+  expect_identical(mp$Parameter, c("Species", "Residuals"))
   expect_equal(mp$Sum_Squares, c(11.34493, 16.962), tolerance = 1e-3)
 })
 
@@ -17,41 +17,41 @@ test_that("model_parameters.aov", {
   skip_if_not_installed("effectsize", minimum_version = "0.5.0")
   model <- aov(Sepal.Width ~ Species, data = iris)
   mp <- suppressMessages(model_parameters(model, effectsize_type = c("omega", "eta", "epsilon")))
-  expect_equal(sum(mp$df), 149)
-  expect_equal(colnames(mp), c(
+  expect_identical(sum(mp$df), 149)
+  expect_names(mp, c(
     "Parameter", "Sum_Squares", "df", "Mean_Square", "F", "p",
     "Omega2", "Eta2", "Epsilon2"
   ))
 
   model <- aov(Sepal.Length ~ Species * Cat1 * Cat2, data = iris)
-  expect_equal(sum(model_parameters(model, effectsize_type = c("omega", "eta", "epsilon"), verbose = FALSE)$df), 149)
+  expect_identical(sum(model_parameters(model, effectsize_type = c("omega", "eta", "epsilon"), verbose = FALSE)$df), 149)
 
   model <- aov(Sepal.Length ~ Species / Cat1 * Cat2, data = iris)
-  expect_equal(sum(model_parameters(model, verbose = FALSE)$df), 149)
+  expect_identical(sum(model_parameters(model, verbose = FALSE)$df), 149)
 })
 
 test_that("model_parameters.anova", {
   skip_if_not_installed("lme4")
   model <- anova(lm(Sepal.Width ~ Species, data = iris))
-  expect_equal(sum(model_parameters(model)$df), 149)
+  expect_identical(sum(model_parameters(model)$df), 149)
 
   model <- anova(lm(Sepal.Length ~ Species * Cat1 * Cat2, data = iris))
-  expect_equal(sum(model_parameters(model)$df), 149)
+  expect_identical(sum(model_parameters(model)$df), 149)
 
   model <- anova(lme4::lmer(wt ~ 1 + (1 | gear), data = mtcars))
-  expect_equal(nrow(model_parameters(model)), 0)
+  expect_identical(nrow(model_parameters(model)), 0)
 
   model <- anova(lme4::lmer(wt ~ cyl + (1 | gear), data = mtcars))
-  expect_equal(sum(model_parameters(model)$df), 1)
+  expect_identical(sum(model_parameters(model)$df), 1)
 
   model <- anova(lme4::lmer(wt ~ drat + cyl + (1 | gear), data = mtcars))
-  expect_equal(sum(model_parameters(model)$df), 2)
+  expect_eexpect_identicalual(sum(model_parameters(model)$df), 2)
 
   model <- anova(lme4::lmer(wt ~ drat * cyl + (1 | gear), data = mtcars))
-  expect_equal(sum(model_parameters(model, verbose = FALSE)$df), 3)
+  expect_identical(sum(model_parameters(model, verbose = FALSE)$df), 3)
 
   model <- anova(lme4::lmer(wt ~ drat / cyl + (1 | gear), data = mtcars))
-  expect_equal(sum(model_parameters(model, verbose = FALSE)$df), 2)
+  expect_identical(sum(model_parameters(model, verbose = FALSE)$df), 2)
 })
 
 
@@ -61,26 +61,26 @@ test_that("model_parameters.anova", {
   skip_if_not_installed("httr")
 
   model <- insight::download_model("anova_3")
-  expect_equal(sum(model_parameters(model, verbose = FALSE)$df), 149)
+  expect_identical(sum(model_parameters(model, verbose = FALSE)$df), 149)
 
   model <- insight::download_model("anova_4")
-  expect_equal(sum(model_parameters(model, verbose = FALSE)$df, na.rm = TRUE), 2)
+  expect_identical(sum(model_parameters(model, verbose = FALSE)$df, na.rm = TRUE), 2)
 
   model <- insight::download_model("anova_lmerMod_5")
-  expect_equal(sum(model_parameters(model, verbose = FALSE)$df), 1)
+  expect_identical(sum(model_parameters(model, verbose = FALSE)$df), 1)
 
   model <- insight::download_model("anova_lmerMod_6")
-  expect_equal(sum(model_parameters(model, verbose = FALSE)$df), 12)
+  expect_identical(sum(model_parameters(model, verbose = FALSE)$df), 12)
 })
 
 
 test_that("model_parameters.anova", {
   model <- aov(wt ~ cyl + Error(gear), data = mtcars)
-  expect_equal(sum(model_parameters(model, verbose = FALSE)$df), 31)
+  expect_identical(sum(model_parameters(model, verbose = FALSE)$df), 31)
 
   model <- aov(Sepal.Length ~ Species * Cat1 + Error(Cat2), data = iris)
-  expect_equal(sum(model_parameters(model, verbose = FALSE)$df), 149)
+  expect_identical(sum(model_parameters(model, verbose = FALSE)$df), 149)
 
   model <- aov(Sepal.Length ~ Species / Cat1 + Error(Cat2), data = iris)
-  expect_equal(sum(model_parameters(model, verbose = FALSE)$df), 149)
+  expect_identical(sum(model_parameters(model, verbose = FALSE)$df), 149)
 })

--- a/tests/testthat/test-model_parameters.epi2x2.R
+++ b/tests/testthat/test-model_parameters.epi2x2.R
@@ -5,8 +5,8 @@ test_that("model_parameters.epi2x2", {
   data(mtacrs)
   tab <- xtabs(~ am + vs, data = mtcars)
   out <- model_parameters(epiR::epi.2by2(tab))
-  expect_identicl(out$Parameter, c("RR", "OR", "ARisk", "AFRisk", "PARisk", "PAFRisk"))
-  expect_identicl(
+  expect_identical(out$Parameter, c("RR", "OR", "ARisk", "AFRisk", "PARisk", "PAFRisk"))
+  expect_identical(
     attributes(out)$pretty_names,
     c(
       RR = "Risk Ratio", OR = "Odds Ratio", ARisk = "Attributable Risk",

--- a/tests/testthat/test-model_parameters.epi2x2.R
+++ b/tests/testthat/test-model_parameters.epi2x2.R
@@ -2,7 +2,7 @@ skip_on_cran()
 skip_if_not_installed("epiR")
 
 test_that("model_parameters.epi2x2", {
-  data(mtacrs)
+  data(mtcars)
   tab <- xtabs(~ am + vs, data = mtcars)
   out <- model_parameters(epiR::epi.2by2(tab))
   expect_identical(out$Parameter, c("RR", "OR", "ARisk", "AFRisk", "PARisk", "PAFRisk"))

--- a/tests/testthat/test-model_parameters.epi2x2.R
+++ b/tests/testthat/test-model_parameters.epi2x2.R
@@ -1,0 +1,17 @@
+skip_on_cran()
+skip_if_not_installed("epiR")
+
+test_that("model_parameters.epi2x2", {
+  data(mtacrs)
+  tab <- xtabs(~ am + vs, data = mtcars)
+  out <- model_parameters(epiR::epi.2by2(tab))
+  expect_identicl(out$Parameter, c("RR", "OR", "ARisk", "AFRisk", "PARisk", "PAFRisk"))
+  expect_identicl(
+    attributes(out)$pretty_names,
+    c(
+      RR = "Risk Ratio", OR = "Odds Ratio", ARisk = "Attributable Risk",
+      AFRisk = "Attributable Fraction in Exposed (%)", PARisk = "Attributable Risk in Population",
+      PAFRisk = "Attributable Fraction in Population (%)"
+    )
+  )
+})


### PR DESCRIPTION
`insight::get_parameters()` returns something named "RR" and not "PR".