### PR TITLE
marginaleffects 0.20.1: minor change in labels

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -151,7 +151,7 @@ Suggests:
     logspline,
     lqmm,
     M3C,
-    marginaleffects (>= 0.16.0),
+    marginaleffects (>= 0.20.1),
     MASS,
     Matrix,
     mclogit,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: parameters
 Title: Processing of Model Parameters
-Version: 0.21.6.6
+Version: 0.21.6.7
 Authors@R:
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -218,4 +218,3 @@ Config/Needs/website:
     r-lib/pkgdown,
     easystats/easystatstemplate
 Config/rcmdcheck/ignore-inconsequential-notes: true
-Remotes: easystats/insight

--- a/R/methods_marginaleffects.R
+++ b/R/methods_marginaleffects.R
@@ -23,6 +23,9 @@ model_parameters.marginaleffects <- function(model,
 
   attr(out, "object_name") <- insight::safe_deparse_symbol(substitute(model))
 
+  # do not print or report these columns
+  out <- out[, !colnames(out) %in% c("predicted_lo", "predicted_hi"), drop = FALSE]
+
   if (inherits(model, "marginalmeans")) {
     attr(out, "coefficient_name") <- "Marginal Means"
   } else if (inherits(model, "comparisons")) {

--- a/tests/testthat/test-marginaleffects.R
+++ b/tests/testthat/test-marginaleffects.R
@@ -8,10 +8,8 @@ test_that("marginaleffects()", {
   model <- marginaleffects::avg_slopes(x, newdata = insight::get_datagrid(x, at = "Species"), variables = "Petal.Length")
   out <- parameters(model)
   expect_identical(nrow(out), 1L)
-  expect_named(out, c(
-    "Parameter", "Coefficient", "SE", "Statistic",
-    "p", "S", "CI", "CI_low", "CI_high"
-  ))
+  cols <- c("Parameter", "Comparison", "Coefficient", "SE", "Statistic", "p", "S", "CI", "CI_low", "CI_high")
+  expect_true(all(cols %in% colnames(out)))
   out <- model_parameters(model, exponentiate = TRUE)
   expect_equal(out$Coefficient, 1.394, tolerance = 1e-3)
 

--- a/tests/testthat/test-model_parameters.coxme.R
+++ b/tests/testthat/test-model_parameters.coxme.R
@@ -1,18 +1,22 @@
 skip_on_cran()
 skip_if_not_installed("coxme")
 skip_if_not_installed("survival")
+skip_if_not_installed("withr")
 
 # modelparameters ----------------------------------
 
-test_that("model_parameters.coxme", {
-  data(eortc, package = "coxme")
-  d <- coxme::eortc
-  d$surv <- survival::Surv(d$y, d$uncens)
-  m1 <- coxme::coxme(surv ~ trt + (1 | center), data = d)
-  out <- model_parameters(m1)
-  expect_named(
-    out,
-    c("Parameter", "Coefficient", "SE", "CI", "CI_low", "CI_high", "z", "df_error", "p")
-  )
-  expect_equal(out$Coefficient, 0.7086127, tolerance = 1e-4)
-})
+withr::with_environment(
+  new.env(),
+  test_that("model_parameters.coxme", {
+    data(eortc, package = "coxme")
+    d <- coxme::eortc
+    d$surv <- survival::Surv(d$y, d$uncens)
+    m1 <- coxme::coxme(surv ~ trt + (1 | center), data = d)
+    out <- model_parameters(m1)
+    expect_named(
+      out,
+      c("Parameter", "Coefficient", "SE", "CI", "CI_low", "CI_high", "z", "df_error", "p")
+    )
+    expect_equal(out$Coefficient, 0.7086127, tolerance = 1e-4)
+  })
+)


### PR DESCRIPTION
Apologies, but there is going to be a minor change in labels in `marginaleffects` 0.21.1. This PR modifies the tests and method to account for that change.