### PR TITLE
Digit arguments ignored for objects created with `marginaleffects::hypotheses()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,11 @@
 
 * Improved printing for `simulate_parameters()` for models from packages *mclogit*.
 
+## Bug fixes
+
+* Arguments like `digits` etc. were ignored in `model_parameters() for objects
+  from the *marginaleffects* package.
+
 # parameters 0.22.2
 
 ## New supported models

--- a/R/methods_marginaleffects.R
+++ b/R/methods_marginaleffects.R
@@ -45,6 +45,15 @@ model_parameters.marginaleffects <- function(model,
   # exponentiate coefficients and SE/CI, if requested
   out <- .exponentiate_parameters(out, model = NULL, exponentiate)
 
+  # add further information as attributes
+  out <- .add_model_parameters_attributes(
+    out,
+    model = model,
+    ci = ci,
+    exponentiate = exponentiate,
+    ...
+  )
+
   class(out) <- c("parameters_model", "see_parameters_model", class(out))
   out
 }
@@ -96,6 +105,15 @@ model_parameters.predictions <- function(model,
 
   # exponentiate coefficients and SE/CI, if requested
   out <- .exponentiate_parameters(out, model = NULL, exponentiate)
+
+  # add further information as attributes
+  out <- .add_model_parameters_attributes(
+    out,
+    model = model,
+    ci = ci,
+    exponentiate = exponentiate,
+    ...
+  )
 
   class(out) <- c("parameters_model", "see_parameters_model", class(out))
   out

--- a/tests/testthat/_snaps/marginaleffects.md
+++ b/tests/testthat/_snaps/marginaleffects.md
@@ -1,0 +1,11 @@
+# digits and ci_digits for marginaleffects
+
+    Code
+      out
+    Output
+      # Fixed Effects
+      
+      Parameter | Coefficient |  SE | Statistic |      p |    S |         95% CI
+      --------------------------------------------------------------------------
+      10*wt = 0 |       -53.4 | 5.6 |      -9.6 | < .001 | 69.5 | [-64.4, -42.5]
+

--- a/tests/testthat/test-marginaleffects.R
+++ b/tests/testthat/test-marginaleffects.R
@@ -102,3 +102,13 @@ test_that("model_parameters defaults to FALSE: Issue #916", {
   out2 <- model_parameters(pred, exponentiate = FALSE)
   expect_equal(out1$Predicted, out2$Predicted, tolerance = 1e-4)
 })
+
+
+test_that("digits and ci_digits for marginaleffects", {
+  data(mtcars)
+  skip_if(getRversion() < "4.2.0")
+  out <- lm(mpg ~ wt, data = mtcars) |>
+    marginaleffects::hypotheses(hypothesis = "10*wt = 0") |>
+    model_parameters(digits = 1)
+  expect_snapshot(out)
+})


### PR DESCRIPTION
Fixes #1024