### PR TITLE
refactor, reduce complexity

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -227,4 +227,4 @@ Config/testthat/parallel: true
 Config/Needs/website: easystats/easystatstemplate
 Config/Needs/check: stan-dev/cmdstanr
 Config/rcmdcheck/ignore-inconsequential-notes: true
-Remotes: easystats/insight
+Remotes: easystats/insight, easystats/bayestestR

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -227,3 +227,4 @@ Config/testthat/parallel: true
 Config/Needs/website: easystats/easystatstemplate
 Config/Needs/check: stan-dev/cmdstanr
 Config/rcmdcheck/ignore-inconsequential-notes: true
+Remotes: easystats/insight

--- a/R/format.R
+++ b/R/format.R
@@ -408,7 +408,6 @@ format.compare_parameters <- function(x,
   indent_groups <- attributes(x)$indent_groups
   indent_rows <- attributes(x)$indent_rows
 
-
   # check whether to split table by certain factors/columns (like component, response...)
   split_by <- split_column <- .prepare_splitby_for_print(x)
 

--- a/R/methods_brms.R
+++ b/R/methods_brms.R
@@ -120,13 +120,11 @@ model_parameters.brmsfit <- function(model,
     )
     params$Effects <- "total"
     class(params) <- c("parameters_coef", "see_parameters_coef", class(params))
-    return(params)
   } else {
-
-    if (utils::packageVersion("insight") > "1.2.0" && effects == "random" && group_level) {
+    # update argument
+    if (effects == "random" && group_level) {
       effects <- "grouplevel"
     }
-
     # Processing
     params <- .extract_parameters_bayesian(
       model,
@@ -148,21 +146,6 @@ model_parameters.brmsfit <- function(model,
       verbose = verbose,
       ...
     )
-
-    ## TODO: remove this once insight > 1.2.0 on CRAN
-
-    # if random effects are included, check if group-level estimates
-    # should be returned or not. If not, remove them.
-    if (effects != "fixed") {
-      random_effect_levels <- which(
-        params$Effects == "random" &
-          grepl("^(?!sd_|cor_)(.*)", params$Parameter, perl = TRUE) &
-          !(params$Parameter %in% c("car", "sdcar"))
-      )
-      if (length(random_effect_levels) && isFALSE(group_level)) {
-        params <- params[-random_effect_levels, ]
-      }
-    }
 
     # add prettified names as attribute. Furthermore, group column is added
     params <- .add_pretty_names(params, model)
@@ -307,18 +290,6 @@ standard_error.brmsfit <- function(model,
                                    effects = "fixed",
                                    component = "all",
                                    ...) {
-
-  ## TODO: remove validation of effects and component once insight > 1.2.0 is on CRAN
-
-  effects <- insight::validate_argument(
-    effects,
-    c("fixed", "random")
-  )
-  component <- insight::validate_argument(
-    component,
-    c("all", "conditional", "zi", "zero_inflated")
-  )
-
   params <- insight::get_parameters(model, effects = effects, component = component, ...)
 
   .data_frame(

--- a/R/methods_glmmTMB.R
+++ b/R/methods_glmmTMB.R
@@ -229,7 +229,7 @@ model_parameters.glmmTMB <- function(model,
   }
 
   # initialize
-  params <- params_random <- params_variance <- NULL
+  params <- NULL
 
   if (effects %in% c("fixed", "all")) {
     # Processing
@@ -287,8 +287,6 @@ model_parameters.glmmTMB <- function(model,
   params <- .add_random_effects_glmmTMB(
     model,
     params,
-    params_random,
-    params_variance,
     ci,
     ci_method,
     ci_random,
@@ -388,8 +386,6 @@ model_parameters.glmmTMB <- function(model,
 # dispersion parameter, if present in random effects
 .add_random_effects_glmmTMB <- function(model,
                                         params,
-                                        params_random,
-                                        params_variance,
                                         ci,
                                         ci_method,
                                         ci_random,
@@ -397,6 +393,7 @@ model_parameters.glmmTMB <- function(model,
                                         component,
                                         dispersion_param,
                                         group_level) {
+  params_random <- params_variance <- NULL
   random_effects <- insight::find_random(model, flatten = TRUE)
 
   if (!is.null(random_effects) && effects %in% c("random", "all")) {

--- a/R/methods_glmmTMB.R
+++ b/R/methods_glmmTMB.R
@@ -276,7 +276,7 @@ model_parameters.glmmTMB <- function(model,
     }
 
     # add dispersion parameter
-    out <- .add_dispersion_param_glmmTMB(model, params, effects, component, verbose)
+    out <- .add_dispersion_param_glmmTMB(model, params, effects, component, ci, verbose)
     params <- out$params
     dispersion_param <- out$dispersion_param
 
@@ -349,7 +349,7 @@ model_parameters.glmmTMB <- function(model,
 
 # this functions adds the dispersion parameter, if it is not already
 # present in the output
-.add_dispersion_param_glmmTMB <- function(model, params, effects, component, verbose) {
+.add_dispersion_param_glmmTMB <- function(model, params, effects, component, ci, verbose) {
   dispersion_param <- FALSE
   if (
     # must be glmmTMB

--- a/R/methods_glmmTMB.R
+++ b/R/methods_glmmTMB.R
@@ -276,7 +276,7 @@ model_parameters.glmmTMB <- function(model,
     }
 
     # add dispersion parameter
-    out <- .add_dispersion_param_glmmTMB(model, params, effects, component)
+    out <- .add_dispersion_param_glmmTMB(model, params, effects, component, verbose)
     params <- out$params
     dispersion_param <- out$dispersion_param
 
@@ -349,7 +349,7 @@ model_parameters.glmmTMB <- function(model,
 
 # this functions adds the dispersion parameter, if it is not already
 # present in the output
-.add_dispersion_param_glmmTMB <- function(model, params, effects, component) {
+.add_dispersion_param_glmmTMB <- function(model, params, effects, component, verbose) {
   dispersion_param <- FALSE
   if (
     # must be glmmTMB

--- a/R/methods_glmmTMB.R
+++ b/R/methods_glmmTMB.R
@@ -233,6 +233,7 @@ model_parameters.glmmTMB <- function(model,
 
   # initialize
   params <- att <- NULL
+  dispersion_param <- FALSE
 
   # fixed effects =================================================
   # ===============================================================

--- a/R/methods_glmmTMB.R
+++ b/R/methods_glmmTMB.R
@@ -293,7 +293,8 @@ model_parameters.glmmTMB <- function(model,
     effects,
     component,
     dispersion_param,
-    group_level
+    group_level,
+    verbose
   )
 
   # remove empty column
@@ -391,7 +392,8 @@ model_parameters.glmmTMB <- function(model,
                                         effects,
                                         component,
                                         dispersion_param,
-                                        group_level) {
+                                        group_level,
+                                        verbose = TRUE) {
   params_random <- params_variance <- NULL
   random_effects <- insight::find_random(model, flatten = TRUE)
 

--- a/R/methods_glmmTMB.R
+++ b/R/methods_glmmTMB.R
@@ -229,7 +229,7 @@ model_parameters.glmmTMB <- function(model,
   }
 
   # initialize
-  params <- NULL
+  params <- att <- NULL
 
   if (effects %in% c("fixed", "all")) {
     # Processing
@@ -279,9 +279,9 @@ model_parameters.glmmTMB <- function(model,
     params <- .exponentiate_parameters(params, model, exponentiate)
 
     params$Effects <- "fixed"
+    att <- attributes(params)
   }
 
-  att <- attributes(params)
 
   # add random effects, either group level or re variances
   params <- .add_random_effects_glmmTMB(
@@ -305,7 +305,6 @@ model_parameters.glmmTMB <- function(model,
   if (!is.null(keep) || !is.null(drop)) {
     params <- .filter_parameters(params, keep, drop, verbose = verbose)
   }
-
 
   # due to rbind(), we lose attributes from "extract_parameters()",
   # so we add those attributes back here...

--- a/R/utils_format.R
+++ b/R/utils_format.R
@@ -995,7 +995,6 @@
     ci_brackets <- c("[", "]")
   }
 
-
   # check ordinal / multivariate
   is_ordinal_model <- isTRUE(attributes(x)$ordinal_model)
   is_multivariate <- isTRUE(attributes(x)$multivariate_response)

--- a/tests/testthat/test-brms.R
+++ b/tests/testthat/test-brms.R
@@ -40,8 +40,8 @@ test_that("mp, dpars in total effects", {
   expect_named(
     out,
     c(
-      "Group", "Level", "Parameter", "Median", "CI", "CI_low", "CI_high",
-      "pd", "Component", "Effects"
+      "Parameter", "Component", "Median", "CI", "CI_low", "CI_high",
+      "pd", "Rhat", "ESS", "Group"
     )
   )
 

--- a/tests/testthat/test-brms.R
+++ b/tests/testthat/test-brms.R
@@ -26,7 +26,33 @@ test_that("mp, dpars in total effects", {
   out <- parameters::model_parameters(m, effects = "total")
   expect_identical(dim(out), c(80L, 10L))
   expect_identical(unique(out$Component), c("conditional", "delta", "k", "phi"))
-  # out <- parameters::model_parameters(m, effects = "random", group_level = TRUE)
-  # expect_identical(dim(out), c(80L, 10L))
-  # expect_identical(unique(out$Component), c("conditional", "delta", "k", "phi"))
+  expect_named(
+    out,
+    c(
+      "Group", "Level", "Parameter", "Median", "CI", "CI_low", "CI_high",
+      "pd", "Component", "Effects"
+    )
+  )
+
+  out <- parameters::model_parameters(m, effects = "grouplevel")
+  expect_identical(dim(out), c(60L, 10L))
+  expect_identical(unique(out$Component), c("conditional", "delta", "k"))
+  expect_named(
+    out,
+    c(
+      "Group", "Level", "Parameter", "Median", "CI", "CI_low", "CI_high",
+      "pd", "Component", "Effects"
+    )
+  )
+
+  out <- parameters::model_parameters(m, effects = "all")
+  expect_identical(dim(out), c(7L, 11L))
+  expect_identical(unique(out$Component), c("conditional", "delta", "k", "phi"))
+  expect_named(
+    out,
+    c(
+      "Parameter", "Effects", "Component", "Median", "CI", "CI_low",
+      "CI_high", "pd", "Rhat", "ESS", "Group"
+    )
+  )
 })

--- a/tests/testthat/test-glmmTMB.R
+++ b/tests/testthat/test-glmmTMB.R
@@ -2,7 +2,7 @@ skip_if_not_installed("withr")
 skip_if_not_installed("glmmTMB")
 skip_if_not(getRversion() >= "4.0.0")
 
-data("fish")
+data("fish", package = "parameters")
 data("Salamanders", package = "glmmTMB")
 
 skip_on_cran()

--- a/tests/testthat/test-glmmTMB.R
+++ b/tests/testthat/test-glmmTMB.R
@@ -77,6 +77,11 @@ withr::with_options(
         tolerance = 1e-3
       )
       expect_equal(
+        standard_error(m1, effects = "random")$persons$`(Intercept)`,
+        c(0.69856, 0.68935, 0.68749, 0.68596),
+        tolerance = 1e-3
+      )
+      expect_equal(
         standard_error(m1, component = "cond")$SE,
         c(0.47559, 0.09305, 0.09346),
         tolerance = 1e-3


### PR DESCRIPTION
TODO
- [ ] We need to save the `effects` argument, so we can detect whether we have `grouplevel` in `.format_columns_multiple_components()`. Currently, group-level estimates have the wrong header, because the `Effects` column is removed, since it only has unique values (`"random"`), but this means that group level effects are not detected as random effects when printing.