### PR TITLE
Adapt tests to fixest v0.13.0

### DIFF
--- a/tests/testthat/test-model_parameters.fixest.R
+++ b/tests/testthat/test-model_parameters.fixest.R
@@ -110,8 +110,8 @@ test_that("robust standard errors", {
   expect_true(all(p2$p != p3$p))
   expect_true(all(p1$p != p3$p))
 
-  expect_error(standard_error(mod, vcov = "HC3"))
-  expect_error(parameters(mod, vcov = "HC3"))
+  expect_error(standard_error(mod, vcov = "HC3"), NA)
+  expect_error(parameters(mod, vcov = "HC3"), NA)
   expect_error(parameters(mod, vcov = "hetero"), NA)
   expect_error(parameters(mod, vcov = "iid"), NA)
 })


### PR DESCRIPTION
Dear Maintainers,

The package `fixest` v0.13.0 will soon be released ([see NEWS](https://github.com/lrberge/fixest/blob/master/NEWS.md)).
In this new version,  `vcov = "HC3"` has been implemented.

This PR concerns the tests. Now using `vcov = "HC3"` does not send an error any more.

Hence I changed the following two lines in the tests:
```
expect_error(standard_error(mod, vcov = "HC3"))
expect_error(parameters(mod, vcov = "HC3"))
```

To:
```
expect_error(standard_error(mod, vcov = "HC3"), NA) 
expect_error(parameters(mod, vcov = "HC3"), NA)
```

Thanks for your consideration.