### PR TITLE
typos and wordsmithing on 'demean' vignette

### DIFF
--- a/vignettes/demean.Rmd
+++ b/vignettes/demean.Rmd
@@ -413,11 +413,15 @@ and include only the within-effects as well as the group-level indicator.
 
 ```{r fe-model-preds, echo = FALSE}
 fe_model <- lm(y ~ 1 + grp + x, data = d)
-fe_pred <- d |>
-  select(-y) |>
-  reframe(x = range(x), x_within = range(x_within),
-          x_between = x_between[1], .by = grp)
-fe_pred$y <- predict(object = fe_model, newdata = fe_pred)
+sumfun <- function(df) {
+  data.frame(
+    grp = df$grp[1],
+    x = range(df$x),
+    x_within = range(df$x_within),
+    x_between = df$x_between[1])
+}
+fe_pred <- do.call(rbind, lapply(split(d, d$grp), sumfun))
+fe_pred$y <- stats::predict(fe_model, newdata = fe_pred)
 ```
 
 ```{r echo=FALSE}
@@ -469,9 +473,9 @@ Since FE-models can only model within-effects, we now use a mixed model with
 within- and between-effects.
 
 ```{r echo = FALSE}
-m4 <- lmer(y ~ x_between + x_within + (1 | grp), data = d)
+m4 <- lme4::lmer(y ~ x_between + x_within + (1 | grp), data = d)
 ri_pred <- fe_pred ## same setup as FE predictions
-ri_pred$y <- predict(object = m4, newdata = fe_pred)
+ri_pred$y <- stats::predict(object = m4, newdata = fe_pred)
 ```
 
 ```{r echo=FALSE}

--- a/vignettes/demean.Rmd
+++ b/vignettes/demean.Rmd
@@ -39,6 +39,7 @@ if (!all(sapply(pkgs, requireNamespace, quietly = TRUE))) {
   knitr::opts_chunk$set(eval = FALSE)
 }
 
+theme_set(see::theme_modern())
 set.seed(333)
 ```
 
@@ -369,7 +370,6 @@ Let's look at the raw data...
 ```{r echo=FALSE}
 ggplot(d, aes(x, y)) +
   geom_point(colour = "#555555", size = 2.5, alpha = 0.5) +
-  see::theme_modern() +
   labs(x = "Typing Speed", y = "Typing Errors", colour = "Type Experience")
 ```
 
@@ -382,7 +382,6 @@ speed.
 ggplot(d, aes(x, y)) +
   geom_point(colour = "#555555", size = 2.5, alpha = 0.5) +
   geom_smooth(method = "lm", se = FALSE, colour = "#555555") +
-  see::theme_modern() +
   labs(x = "Typing Speed", y = "Typing Errors", colour = "Type Experience")
 ```
 
@@ -402,7 +401,6 @@ ggplot(d, aes(x, y)) +
   geom_point(mapping = aes(colour = grp), size = 2.5, alpha = 0.5) +
   geom_smooth(method = "lm", se = FALSE, colour = "#555555") +
   see::scale_color_flat() +
-  see::theme_modern() +
   labs(x = "Typing Speed", y = "Typing Errors", colour = "Type Experience")
 ```
 
@@ -430,7 +428,6 @@ ggplot(d, aes(x, y)) +
   ## geom_smooth(mapping = aes(colour = grp), method = "lm", se = FALSE) +
   geom_point(mapping = aes(colour = grp), size = 2.2, alpha = 0.6) +
   see::scale_color_flat() +
-  see::theme_modern() +
   labs(x = "Typing Speed", y = "Typing Errors", colour = "Type Experience")
 ```
 
@@ -455,7 +452,6 @@ ggplot(d, aes(x, y)) +
   geom_point(mapping = aes(colour = grp), size = 2.2, alpha = 0.6) +
   geom_smooth(mapping = aes(x = x_between, y = y_between), method = "lm", se = FALSE, colour = "#444444") +
   see::scale_color_flat() +
-  see::theme_modern() +
   labs(x = "Typing Speed", y = "Typing Errors", colour = "Type Experience")
 ```
 
@@ -485,7 +481,6 @@ ggplot(d, aes(x, y)) +
   geom_point(mapping = aes(colour = grp), size = 2.2, alpha = 0.6) +
   geom_smooth(mapping = aes(x = x_between, y = y_between), method = "lm", se = FALSE, colour = "#444444") +
   see::scale_color_flat() +
-  see::theme_modern() +
   labs(x = "Typing Speed", y = "Typing Errors", colour = "Type Experience")
 ```
 

--- a/vignettes/demean.Rmd
+++ b/vignettes/demean.Rmd
@@ -80,7 +80,7 @@ level-2 variable. Predictors at level-1 ("fixed effects"), e.g. self-rated
 health or income, now have an effect at level-1 ("within"-effect) and at
 higher-level units (level-2, the subject-level, which is the "between"-effect)
 (see also [this posting](https://shouldbewriting.netlify.app/posts/2019-10-21-accounting-for-within-and-between-subject-effect/)).
-This inevitably leads to correlating fixed effects and error terms - which, in
+This inevitably leads to correlating fixed effects and error terms &mdash; which, in
 turn, results in biased estimates, because both the within- *and* between-effect
 are captured in *one* estimate.
 
@@ -92,7 +92,7 @@ library(performance)
 check_group_variation(qol_cancer, select = c("phq4", "education"), by = "ID")
 ```
 
-# Adressing heterogeneity bias: the Fixed Effects Regression (FE) approach
+# Addressing heterogeneity bias: the Fixed Effects Regression (FE) approach
 
 Fixed effects regression models (FE) are a popular approach for panel data
 analysis in particular in econometrics and considered as gold standard. To avoid
@@ -170,7 +170,7 @@ multilevel model with varying intercepts (or coefficients) when the units and
 predictors correlate? The answer is yes. And the solution is simple."
 [@bafumi_fitting_2006]
 
-# Adressing heterogeneity bias: the Mixed Model approach
+# Addressing heterogeneity bias: the Mixed Model approach
 
 Mixed models include different levels of sources of variability (i.e. error
 terms at each level). Predictors used at level-1 that are varying across
@@ -180,17 +180,17 @@ the higher-level entity that does not vary between occasions, and one that
 represents the difference between occasions, within higher-level entities"
 [@bell_explaining_2015]. Hence, the error terms will be correlated with the
 covariate, which violates one of the assumptions of mixed models (iid,
-independent and identically distributed error terms) - also known and described
+independent and identically distributed error terms) &mdash; also known and described
 above as _heterogeneity bias_.
 
 But how can this issue be addressed outside the FE framework?
 
-There are several ways how to address this using a mixed models approach:
+There are several ways to address this using a mixed models approach:
 
   * Correlated group factors and predictors are no problem anyway, because
     [partial
     pooling](https://www.tjmahr.com/plotting-partial-pooling-in-mixed-effects-models/)
-    allows estimates of units o borrow strength from the whole sample and shrink
+    allows estimates of units to borrow strength from the whole sample and shrink
     toward a common mean (@shor_bayesian_2007).
 
   * If predictor and group factors correlate, one can remove this correlation by
@@ -199,7 +199,7 @@ There are several ways how to address this using a mixed models approach:
 
   * When time-varying predictors are "decomposed" into their time-varying and
     time-invariant components (de-meaning), then mixed models can model **both**
-    within- and between-subject effects [@bell_fixed_2019] - this approach is
+    within- and between-subject effects [@bell_fixed_2019] &mdash; this approach is
     essentially a further development of a long-known recommendation by Mundlak
     [@mundlak_pooling_1978].
 
@@ -225,7 +225,7 @@ specification [@mundlak_pooling_1978]. As such, when the (mixed) model is
 properly specified, the estimator of the mixed model is identical to the
 'within' (i.e. FE) estimator.
 
-As a consequence, we cannot only use the above specified mixed model for panel
+As a consequence, not only can we use the mixed model specified above for panel
 data, we can even specify more complex models including within-effects,
 between-effects or random effects variation. A mixed models approach can model
 the causes of endogeneity explicitly by including the (separated) within- and
@@ -243,7 +243,7 @@ model_parameters(mixed_2, effects = "fixed")
 ```
 
 For more complex models, within-effects will naturally change slightly and are
-no longer identical to simpler FE models. This is no "bias", but rather the
+no longer identical to simpler FE models. This is not "bias", but rather the
 result of building more complex models: FE models lack information of variation
 in the group-effects or between-subject effects. Furthermore, FE models cannot
 include random slopes, which means that fixed effects regressions are neglecting
@@ -263,7 +263,7 @@ knitr::asis_output(f)
 ```
 
 ```{r echo=FALSE}
-f <- "<ul><li>x<sub>it</sub> - &#x035E;x<sub>i</sub> is the de-meaned predictor, <em>phq4_within</em></li><li>&#x035E;x<sub>i</sub> is the group-meaned predictor, <em>phq4_between</em></li><li>&beta;<sub>1W</sub> is the coefficient for phq4_within (within-subject)</li><li>&beta;<sub>2B</sub> is the coefficient for phq4_between (bewteen-subject)</li><li>&beta;<sub>3</sub> is the coefficient for time-constant predictors, such as `hospital` or `education` (bewteen-subject)</li></ul>"
+f <- "<ul><li>x<sub>it</sub> - &#x035E;x<sub>i</sub> is the de-meaned predictor, <em>phq4_within</em></li><li>&#x035E;x<sub>i</sub> is the group-meaned predictor, <em>phq4_between</em></li><li>&beta;<sub>1W</sub> is the coefficient for phq4_within (within-subject)</li><li>&beta;<sub>2B</sub> is the coefficient for phq4_between (between-subject)</li><li>&beta;<sub>3</sub> is the coefficient for time-constant predictors, such as `hospital` or `education` (between-subject)</li></ul>"
 knitr::asis_output(f)
 ```
 
@@ -310,7 +310,7 @@ random_parameters(rewb)
 
 See little example after the visual example below...
 
-# Context effect - how the environment shapes the individual
+# Context effect &mdash; how the environment shapes the individual
 
 Conceptually, when analyzing clustered or longitudinal data, we are looking at two distinct levels of influence:
 
@@ -326,14 +326,14 @@ To test whether the within- and between-effects are significantly different from
 
 First, we generate some fake data that implies a linear relationship between
 outcome and independent variable. The objective is that the amount of typing
-errors depends on how fast (typing speed) you can type, however, the more typing
+errors depends on how fast you can type (typing speed); however, the more typing
 experience you have, the faster you can type. Thus, the outcome measure is
 "amount of typing errors", while our predictor is "typing speed". Furthermore,
 we have repeated measurements of people with different "typing experience
 levels".
 
 The results show that we will have two sources of variation: Overall, more
-experienced typists make less mistakes (group-level pattern). When typing
+experienced typists make fewer mistakes (group-level pattern). When typing
 faster, typists make more mistakes (individual-level pattern).
 
 ```{r}
@@ -498,7 +498,7 @@ observation per group is similar or the same.
 
 Whenever group size is imbalanced, the "simple" linear slope will be adjusted.
 This leads to different estimates for between-effects between classical and
-mixed models regressions due to shrinkage - i.e. for larger variation of group
+mixed models regressions due to shrinkage &mdash; i.e. for larger variation of group
 sizes we find stronger regularization of estimates.
 
 Hence, for mixed models with larger differences in number of observation per
@@ -544,7 +544,7 @@ m2 <- lmer(y ~ x_between + (1 | grp), data = d)
 model_parameters(m2)
 ```
 
-# A final note - latent mean centering
+# A final note &mdash; latent mean centering
 
 It can be even more complicated. The person-mean is only observed, but the
 true value is not known. Thus, in certain situations, the coefficients after

--- a/vignettes/demean.Rmd
+++ b/vignettes/demean.Rmd
@@ -419,7 +419,7 @@ sumfun <- function(df) {
     x_between = df$x_between[1])
 }
 fe_pred <- do.call(rbind, lapply(split(d, d$grp), sumfun))
-fe_pred$y <- stats::predict(fe_model, newdata = fe_pred)
+fe_pred$y <- predict(fe_model, newdata = fe_pred)
 ```
 
 ```{r echo=FALSE}
@@ -469,9 +469,9 @@ Since FE-models can only model within-effects, we now use a mixed model with
 within- and between-effects.
 
 ```{r echo = FALSE}
-m4 <- lme4::lmer(y ~ x_between + x_within + (1 | grp), data = d)
+m4 <- lmer(y ~ x_between + x_within + (1 | grp), data = d)
 ri_pred <- fe_pred ## same setup as FE predictions
-ri_pred$y <- stats::predict(object = m4, newdata = fe_pred)
+ri_pred$y <- predict(object = m4, newdata = fe_pred)
 ```
 
 ```{r echo=FALSE}

--- a/vignettes/demean.Rmd
+++ b/vignettes/demean.Rmd
@@ -14,7 +14,7 @@ editor_options:
 bibliography: bibliography.bib
 ---
 
-```{r , include=FALSE}
+```{r setup, include=FALSE}
 library(knitr)
 knitr::opts_chunk$set(
   echo = TRUE,
@@ -39,7 +39,7 @@ if (!all(sapply(pkgs, requireNamespace, quietly = TRUE))) {
   knitr::opts_chunk$set(eval = FALSE)
 }
 
-theme_set(see::theme_modern())
+ggplot2::theme_set(see::theme_modern())
 set.seed(333)
 ```
 
@@ -504,6 +504,21 @@ standard errors for the within-effect.
 m5 <- lmer(y ~ x_between + x_within + (1 + x_within | grp), data = d)
 model_parameters(m5)
 ```
+
+```{r crewb-fit, echo = FALSE}
+crewb_pred <- fe_pred ## same setup as FE predictions
+crewb_pred$y <- predict(object = m5, newdata = crewb_pred)
+ggplot(d, aes(x, y)) +
+  geom_line(data = crewb_pred, aes(colour = grp)) +
+  geom_line(data = ri_pred, aes(colour = grp), lty = 2) +
+  geom_point(mapping = aes(colour = grp), size = 2.2, alpha = 0.6) +
+  geom_smooth(mapping = aes(x = x_between, y = y_between), method = "lm", se = FALSE, colour = "#444444") +
+  see::scale_color_flat() +
+  labs(x = "Typing Speed", y = "Typing Errors", colour = "Type Experience")
+```
+
+The within-group regression lines are now *slightly* non-parallel. However, the lines are only ever so slightly different, because (1) the groups as simulated actually have the same within-group slope, and (2) the random-slope model always tries to shrink the individual within-group slopes toward the overall average (within-group) slope. The among-group standard deviation of the slope is `r round(attr(VarCorr(m5)$grp, "stddev")[["x_within"]],2)`, relative to an average within-group slope of `r round(fixef(m5)[["x_within"]],2)`; for reference, the parallel lines from the previous model are shown as dashed lines.
+
 
 # Balanced versus imbalanced groups
 

--- a/vignettes/demean.Rmd
+++ b/vignettes/demean.Rmd
@@ -411,9 +411,18 @@ ggplot(d, aes(x, y)) +
 A fixed effects regression (FE-regression) would now remove all between-effects
 and include only the within-effects as well as the group-level indicator.
 
+```{r randint-model-preds, echo = FALSE}
+ri_model <- lm(y ~ 1 + grp + x, data = d)
+ri_pred <- d |>
+  select(-y) |>
+  reframe(x = range(x), .by = grp)
+ri_pred$y <- predict(object = ri_model, newdata = ri_pred)
+```
+
 ```{r echo=FALSE}
 ggplot(d, aes(x, y)) +
-  geom_smooth(mapping = aes(colour = grp), method = "lm", se = FALSE) +
+  geom_line(data = ri_pred, aes(colour = grp)) +
+  ## geom_smooth(mapping = aes(colour = grp), method = "lm", se = FALSE) +
   geom_point(mapping = aes(colour = grp), size = 2.2, alpha = 0.6) +
   see::scale_color_flat() +
   see::theme_modern() +

--- a/vignettes/demean.Rmd
+++ b/vignettes/demean.Rmd
@@ -411,17 +411,18 @@ ggplot(d, aes(x, y)) +
 A fixed effects regression (FE-regression) would now remove all between-effects
 and include only the within-effects as well as the group-level indicator.
 
-```{r randint-model-preds, echo = FALSE}
-ri_model <- lm(y ~ 1 + grp + x, data = d)
-ri_pred <- d |>
+```{r fe-model-preds, echo = FALSE}
+fe_model <- lm(y ~ 1 + grp + x, data = d)
+fe_pred <- d |>
   select(-y) |>
-  reframe(x = range(x), .by = grp)
-ri_pred$y <- predict(object = ri_model, newdata = ri_pred)
+  reframe(x = range(x), x_within = range(x_within),
+          x_between = x_between[1], .by = grp)
+fe_pred$y <- predict(object = fe_model, newdata = fe_pred)
 ```
 
 ```{r echo=FALSE}
 ggplot(d, aes(x, y)) +
-  geom_line(data = ri_pred, aes(colour = grp)) +
+  geom_line(data = fe_pred, aes(colour = grp)) +
   ## geom_smooth(mapping = aes(colour = grp), method = "lm", se = FALSE) +
   geom_point(mapping = aes(colour = grp), size = 2.2, alpha = 0.6) +
   see::scale_color_flat() +
@@ -467,9 +468,16 @@ model_parameters(m3)
 Since FE-models can only model within-effects, we now use a mixed model with
 within- and between-effects.
 
+```{r echo = FALSE}
+m4 <- lmer(y ~ x_between + x_within + (1 | grp), data = d)
+ri_pred <- fe_pred ## same setup as FE predictions
+ri_pred$y <- predict(object = m4, newdata = fe_pred)
+```
+
 ```{r echo=FALSE}
 ggplot(d, aes(x, y)) +
-  geom_smooth(mapping = aes(colour = grp), method = "lm", se = FALSE) +
+  ## geom_smooth(mapping = aes(colour = grp), method = "lm", se = FALSE) +
+  geom_line(data = ri_pred, aes(colour = grp)) +
   geom_point(mapping = aes(colour = grp), size = 2.2, alpha = 0.6) +
   geom_smooth(mapping = aes(x = x_between, y = y_between), method = "lm", se = FALSE, colour = "#444444") +
   see::scale_color_flat() +


### PR DESCRIPTION
* Some straightforward typographical corrections, although a few of them (substitution of em-dashes for hyphens where appropriate, a little bit of wordsmithing) are a little more opinionated
* I changed the plot for "Model 2" (fixed effect) to use the correct model, i.e. to use a FE model to get parallel slopes, which is not what happens when using `geom_smooth(method = "lm")`)
* I think Model 4 should also be changed to correspond to the model actually fitted (which may look *very* slightly different from Model 2 as there is also shrinkage in the intercept estimates). I did the same for Model 4 (although I'm not sure that the predictions are actually any different, since the fit is singular?  Is this something you want to mention in a footnote?)
* Is it worth adding a figure for Model 5 that would show the predictions of the random-slopes model? I can do that if you like ...
* 