### PR TITLE
parameters::parameters() ignores vcov arg when specified as sandwich::NeweyWest

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: parameters
 Title: Processing of Model Parameters
-Version: 0.29.1.3
+Version: 0.29.1.4
 Authors@R:
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,9 @@
 * Fixed issue where `include_reference = TRUE` had no effect for
   `pscl::zeroinfl()` and `pscl::hurdle()` models (#1130).
 
+* Fixed issue with calculation of standard errors in `model_parameters()` when
+  `vcov` was a function that errored when unsupported arguments were passed.
+
 # parameters 0.29.1
 
 ## Changes

--- a/R/4_standard_error.R
+++ b/R/4_standard_error.R
@@ -107,7 +107,7 @@ standard_error.default <- function(
   # vcov: function which returns a matrix
   if (is.function(vcov)) {
     fun_args <- c(list(model), vcov_args)
-    se <- .safe(sqrt(diag(do.call("vcov", fun_args))))
+    se <- .safe(sqrt(diag(do.call(vcov, fun_args))))
   }
 
   # vcov: character

--- a/R/4_standard_error.R
+++ b/R/4_standard_error.R
@@ -106,7 +106,7 @@ standard_error.default <- function(
 
   # vcov: function which returns a matrix
   if (is.function(vcov)) {
-    fun_args <- c(list(model), vcov_args, dots)
+    fun_args <- c(list(model), vcov_args)
     se <- .safe(sqrt(diag(do.call("vcov", fun_args))))
   }
 

--- a/R/methods_nestedLogit.R
+++ b/R/methods_nestedLogit.R
@@ -107,7 +107,7 @@ standard_error.nestedLogit <- function(
   # vcov: function which returns a matrix
   if (is.function(vcov)) {
     fun_args <- c(list(model), vcov_args)
-    se <- .safe(sqrt(diag(do.call("vcov", fun_args))))
+    se <- .safe(sqrt(diag(do.call(vcov, fun_args))))
   }
 
   # vcov: character

--- a/R/methods_nestedLogit.R
+++ b/R/methods_nestedLogit.R
@@ -106,7 +106,7 @@ standard_error.nestedLogit <- function(
 
   # vcov: function which returns a matrix
   if (is.function(vcov)) {
-    fun_args <- c(list(model), vcov_args, dots)
+    fun_args <- c(list(model), vcov_args)
     se <- .safe(sqrt(diag(do.call("vcov", fun_args))))
   }
 

--- a/R/methods_plm.R
+++ b/R/methods_plm.R
@@ -28,7 +28,7 @@ standard_error.plm <- function(
   # vcov: function which returns a matrix
   if (is.function(vcov)) {
     fun_args <- c(list(model), vcov_args)
-    se <- .safe(sqrt(diag(do.call("vcov", fun_args))))
+    se <- .safe(sqrt(diag(do.call(vcov, fun_args))))
   }
 
   # vcov: character (with backward compatibility for `robust = TRUE`)

--- a/R/methods_plm.R
+++ b/R/methods_plm.R
@@ -27,7 +27,7 @@ standard_error.plm <- function(
 
   # vcov: function which returns a matrix
   if (is.function(vcov)) {
-    fun_args <- c(list(model), vcov_args, dots)
+    fun_args <- c(list(model), vcov_args)
     se <- .safe(sqrt(diag(do.call("vcov", fun_args))))
   }
 

--- a/tests/testthat/test-robust.R
+++ b/tests/testthat/test-robust.R
@@ -20,6 +20,29 @@ test_that("robust-se lm", {
   expect_equal(se1$SE, se2, tolerance = 1e-4, ignore_attr = TRUE)
 })
 
+test_that("robust-se, using vcov-fun, lm", {
+  data(AirPassengers)
+  d <- data.frame(
+    t.index = as.integer(factor(time(AirPassengers))) - 1,
+    t.year = floor(time(AirPassengers)),
+    t.month = factor(cycle(AirPassengers), labels = month.name),
+    n.total = as.vector(AirPassengers)
+  )
+  d <- within(d, {
+    tx <- t.index >= 100
+    t.tx <- cumsum(tx)
+    t.tx <- ifelse(tx == TRUE, yes = t.tx - 1, no = 0)
+  })
+  mod.i <- lm(n.total ~ t.index + tx + t.tx, data = d)
+  out <- model_parameters(mod.i, vcov = sandwich::NeweyWest, vcov_args = list(lag = 3))
+  expect_equal(
+    out$SE,
+    sqrt(diag(sandwich::NeweyWest(mod.i, lag = 3))),
+    tolerance = 1e-4,
+    ignore_attr = TRUE
+  )
+})
+
 test_that("robust-se polr", {
   skip_if_not_installed("MASS")
   data(housing, package = "MASS")


### PR DESCRIPTION
Fixes #1229